### PR TITLE
Feathers-Vuex Update - Working with models. Make current user globally available

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -63,6 +63,10 @@ module.exports = {
 			src: "@plugins/authenticate",
 			ssr: false,
 		},
+		{
+			src: "@plugins/auth",
+			ssr: false,
+		},
 		"@plugins/global",
 		"@plugins/directives",
 		"@plugins/theme",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"@storybook/addon-centered": "^4.1.11",
 		"@storybook/addon-viewport": "^4.1.11",
 		"cookie-storage": "^3.2.0",
-		"feathers-vuex": "^1.6.2",
+		"feathers-vuex": "1.7.0",
 		"handlebars": "^4.0.12",
 		"handlebars-layouts": "^3.1.4",
 		"handlebars-wax": "^6.1.0",

--- a/src/pages/teams/_id/edit.vue
+++ b/src/pages/teams/_id/edit.vue
@@ -19,6 +19,7 @@
 			<BaseInput
 				v-model="team.name"
 				label="Name"
+				name="name"
 				type="text"
 				placeholder="Dream Team"
 				maxlength="30"
@@ -26,7 +27,8 @@
 			<BaseInput
 				v-model="team.description"
 				label="Beschreibung"
-				type="textarea"
+				name="description"
+				type="text"
 				placeholder="Everything you have to know"
 				maxlength="255"
 			></BaseInput>
@@ -40,61 +42,64 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from "vuex";
-
 export default {
-	computed: {
-		...mapGetters("teams", {
-			team: "current",
-		}),
+	data () {
+		return {
+			team: {}
+		};
 	},
-	created(ctx) {
-		this.get(this.$route.params.id);
+	async created () {
+		const { Team } = this.$FeathersVuex;
+		this.team = await Team.get(this.$route.params.id)
 	},
 	methods: {
-		...mapActions("teams", ["remove"]),
-		confirmDelete() {
-			this.$dialog.confirm({
-				title: "Team löschen",
-				message: "Bist du sicher, dass du das Team löschen möchtest?",
-				confirmText: "Team löschen",
-				type: "is-danger",
-				hasIcon: true,
-				onConfirm: async () => {
-					try {
-						await this.remove(this.team._id);
-						this.$toast.open("Team gelöscht");
-						this.$router.push({ name: "teams" });
-					} catch (e) {
-						this.$toast.open({
-							message: "Fehler beim löschen",
-							type: "is-danger",
-						});
-					}
-				},
-			});
-		},
-		get(id) {
-			this.$store.dispatch("teams/get", id);
+		async confirmDelete() {
+			// TODO: Dialog
+
+			// this.$dialog.confirm({
+			// 	title: "Team löschen",
+			// 	message: "Bist du sicher, dass du das Team löschen möchtest?",
+			// 	confirmText: "Team löschen",
+			// 	type: "is-danger",
+			// 	hasIcon: true,
+			// 	onConfirm: async () => {
+			// 		try {
+			// 			await this.remove(this.team._id);
+			// 			this.$toast.open("Team gelöscht");
+			// 			this.$router.push({ name: "teams" });
+			// 		} catch (e) {
+			// 			this.$toast.open({
+			// 				message: "Fehler beim löschen",
+			// 				type: "is-danger",
+			// 			});
+			// 		}
+			// 	},
+			// });
+
+			try {
+				await this.team.remove()
+	
+				this.$router.push({ name: "teams" });
+			} catch (e) {
+				console.log(e)
+			}
 		},
 		async save() {
 			try {
-				await this.$store.dispatch("teams/patch", [
-					this.$route.params.id,
-					{
-						name: this.team.name,
-						description: this.team.description,
-					},
-				]);
-				this.$toast.open({
-					message: "Team gespeichert",
-					type: "is-success",
-				});
+				await this.team.save();
+
+				// this.$toast.open({
+				// 	message: "Team gespeichert",
+				// 	type: "is-success",
+				// });
+
+				this.$router.push({ name: "teams-id", params: { id: this.team._id } });
 			} catch (e) {
-				this.$toast.open({
-					message: "Fehler beim Speichern",
-					type: "is-danger",
-				});
+				console.log(e)
+				// this.$toast.open({
+				// 	message: "Fehler beim Speichern",
+				// 	type: "is-danger",
+				// });
 			}
 		},
 	},

--- a/src/pages/teams/_id/edit.vue
+++ b/src/pages/teams/_id/edit.vue
@@ -81,7 +81,7 @@ export default {
 	
 				this.$router.push({ name: "teams" });
 			} catch (e) {
-				console.log(e)
+				// console.log(e)
 			}
 		},
 		async save() {
@@ -95,7 +95,7 @@ export default {
 
 				this.$router.push({ name: "teams-id", params: { id: this.team._id } });
 			} catch (e) {
-				console.log(e)
+				// console.log(e)
 				// this.$toast.open({
 				// 	message: "Fehler beim Speichern",
 				// 	type: "is-danger",

--- a/src/pages/teams/create.vue
+++ b/src/pages/teams/create.vue
@@ -24,10 +24,10 @@
 </template>
 
 <script>
-import { mapState, mapActions } from "vuex";
+import { mapState } from "vuex";
 
 export default {
-	data() {
+	data () {
 		const { Team } = this.$FeathersVuex;
 		const team = new Team()
 
@@ -62,8 +62,7 @@ export default {
 				// 	type: "is-danger",
 				// });
 			}
-		},
-		...mapActions("auth", ["logout"]),
+		}
 	},
 };
 </script>

--- a/src/pages/teams/create.vue
+++ b/src/pages/teams/create.vue
@@ -48,7 +48,7 @@ export default {
 
 				this.$router.push({ name: "teams-id", params: { id: team._id } });
 			} catch (e) {
-				console.log(e)
+				// console.log(e)
 
 				// this.$toast.open({
 				// 	message: "Fehler beim Erstellen des Teams",

--- a/src/pages/teams/create.vue
+++ b/src/pages/teams/create.vue
@@ -24,8 +24,6 @@
 </template>
 
 <script>
-import { mapState } from "vuex";
-
 export default {
 	data () {
 		const { Team } = this.$FeathersVuex;
@@ -35,15 +33,10 @@ export default {
 			team
 		};
 	},
-	computed: {
-		...mapState("auth", {
-			user: "user",
-		}),
-	},
 	methods: {
 		async create(id) {
 			const { Team } = this.$FeathersVuex;
-			this.team.schoolId = this.user.schoolId;
+			this.team.schoolId = this.$user.schoolId;
 
 			try {
 				const team = await this.team.create(); 

--- a/src/pages/teams/create.vue
+++ b/src/pages/teams/create.vue
@@ -6,13 +6,15 @@
 				v-model="team.name"
 				label="Name"
 				type="text"
+				name="name"
 				placeholder="Dream Team"
 				maxlength="30"
 			></BaseInput>
 			<BaseInput
 				v-model="team.description"
 				label="Beschreibung"
-				type="textarea"
+				type="text"
+				name="description"
 				placeholder="Everything you have to know"
 				maxlength="255"
 			></BaseInput>
@@ -26,11 +28,11 @@ import { mapState, mapActions } from "vuex";
 
 export default {
 	data() {
+		const { Team } = this.$FeathersVuex;
+		const team = new Team()
+
 		return {
-			team: {
-				name: "",
-				description: "",
-			},
+			team
 		};
 	},
 	computed: {
@@ -40,24 +42,25 @@ export default {
 	},
 	methods: {
 		async create(id) {
-			try {
-				const team = await this.$store.dispatch("teams/create", {
-					schoolId: this.user.schoolId,
-					name: this.team.name,
-					description: this.team.description,
-				});
+			const { Team } = this.$FeathersVuex;
+			this.team.schoolId = this.user.schoolId;
 
-				this.$toast.open({
-					message: "Team erstellt",
-					type: "is-success",
-				});
+			try {
+				const team = await this.team.create(); 
+
+				// this.$toast.open({
+				// 	message: "Team erstellt",
+				// 	type: "is-success",
+				// });
 
 				this.$router.push({ name: "teams-id", params: { id: team._id } });
 			} catch (e) {
-				this.$toast.open({
-					message: "Fehler beim Erstellen des Teams",
-					type: "is-danger",
-				});
+				console.log(e)
+
+				// this.$toast.open({
+				// 	message: "Fehler beim Erstellen des Teams",
+				// 	type: "is-danger",
+				// });
 			}
 		},
 		...mapActions("auth", ["logout"]),

--- a/src/pages/teams/index.vue
+++ b/src/pages/teams/index.vue
@@ -9,13 +9,11 @@
 		</section>
 		<section class="section">
 			<Card v-for="(team, i) of teams" :key="i">
-				<div slot="header" class="card-image">
-					jo
-				</div>
+				<div slot="header" class="card-image"></div>
 				<div class="card-content">
 					<div class="media">
 						<div class="media-content">
-							<p class="title is-4">{{ team.title }}</p>
+							<p class="title is-4">{{ team.name }}</p>
 							<!-- <p class="subtitle is-6">
 								<span v-for="(tag, index) of data.tags" :key="index" class="tag">
 									{{ tag }}

--- a/src/pages/teams/index.vue
+++ b/src/pages/teams/index.vue
@@ -8,33 +8,41 @@
 			>
 		</section>
 		<section class="section">
-			<div class="tile is-ancestor">
-				<div v-for="(team, i) of teams" :key="i" class="tile is-parent is-4">
-					<article
-						:class="{
-							'is-primary': i % 3 == 0,
-							'is-info': i % 3 == 1,
-							'is-success': i % 3 == 2,
-						}"
-						class="tile is-child notification"
-					>
-						<p class="title">{{ team.name }}</p>
-						<p class="subtitle">{{ team.description }}</p>
-						<p>
-							<BaseLink :to="{ name: 'teams-id', params: { id: team._id } }"
-								>Anschauen</BaseLink
-							>
-						</p>
-					</article>
+			<Card v-for="(team, i) of teams" :key="i">
+				<div slot="header" class="card-image">
+					jo
 				</div>
-			</div>
+				<div class="card-content">
+					<div class="media">
+						<div class="media-content">
+							<p class="title is-4">{{ team.title }}</p>
+							<!-- <p class="subtitle is-6">
+								<span v-for="(tag, index) of data.tags" :key="index" class="tag">
+									{{ tag }}
+								</span>
+							</p> -->
+						</div>
+					</div>
+
+					<div class="content">
+						<p>{{ team.description }}</p>
+					</div>
+				</div>					
+				<div slot="footer">
+					<div class="footer-actions">
+						<BaseLink :to="{ name: 'teams-id', params: { id: team._id } }"
+							>Anschauen</BaseLink
+						>
+					</div>
+				</div>					
+			</Card>
 		</section>
 	</div>
 </template>
 
 <script>
-import { mapGetters } from "vuex";
 import isAuthenticated from "@middleware/is-authenticated";
+import Card from "@components/ui/BaseCard";
 
 export default {
 	head() {
@@ -42,14 +50,17 @@ export default {
 			title: "Teams",
 		};
 	},
-	middleware: [isAuthenticated],
-	computed: {
-		...mapGetters("teams", {
-			teams: "list",
-		}),
+	components: {
+		Card
 	},
-	created(ctx) {
-		this.find();
+	data () {
+		return {
+			teams: []
+		}
+	},
+	middleware: [isAuthenticated],
+	async created(ctx) {
+		this.teams = (await this.$FeathersVuex.Team.find()).data;
 	},
 	methods: {
 		find() {

--- a/src/plugins/auth.js
+++ b/src/plugins/auth.js
@@ -1,0 +1,10 @@
+import Vue from 'vue';
+import { mapState } from 'vuex';
+
+export const mixin = {
+    computed : mapState("auth", {
+        $user: "user",
+    })
+};
+
+Vue.mixin(mixin);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -36,7 +36,13 @@ if (process.client) {
 			replaceItems: true,
 		}),
 		browserService("courses", { paginate: true }),
-		browserService("teams", { paginate: true }),
+		browserService("teams", { 
+			instanceDefaults: {
+				name: '',
+				description: ''
+			},
+			paginate: true,
+		 }),
 		browserService("news", { paginate: true }),
 		browserService("schools", { paginate: true }),
 		browserService("users", { paginate: true }),

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,3 +1,4 @@
+import Vue from "vue";
 import Vuex from "vuex";
 // import { app } from './feathers-client'
 import { CookieStorage } from "cookie-storage";
@@ -20,10 +21,12 @@ if (process.client) {
 			secure: false,
 		})
 	);
-	const { service: browserService, auth: browserAuth } = feathersVuex(
+	const { service: browserService, auth: browserAuth, FeathersVuex } = feathersVuex(
 		browserClient,
 		{ idField: "_id", enableEvents: enableEvents }
 	);
+
+	Vue.use(FeathersVuex);
 
 	plugins = [
 		browserService("/content/search", {
@@ -70,10 +73,12 @@ const createStore = () => {
 
 				// Create a new client for the server
 				const client = feathersClient(origin, storage);
-				const { service } = feathersVuex(client, {
+				const { service, FeathersVuex } = feathersVuex(client, {
 					idField: "_id",
 					enableEvents: false,
 				});
+
+				Vue.use(FeathersVuex);
 
 				// Register services for the server
 				service("users", { paginate: true })(store);


### PR DESCRIPTION
Adding Feathers-Vuex 1.7.0. Now we can use real Models instances and use CRUD operations and also custom operations.

**important**
Run 'yarn' so that feathers-vuex will be updated. Otherwise the models are not working.

Example is provided with the teams pages.

- Create empty team object
--> const team = new Team();

- Create team in the database
--> await team.create() 
--> await team.save() also uses create, if the team has no _id.

- Get list of teams
--> const teams = await Team.find();

- Get single team
--> const team = await Team.get(id);

- Save (Patch) single team
--> await team.save();

- Delete team
--> await team.remove()

In the store/index.js we can now also define default values for models which is very convenient. So we just create an empty model with e.g. "team = new Team()". And from there on we can work directly on the model.

Furthermore the current user is now available as this.$user. The reason is that the user object is needed very often so we don't have to get it from the store in every component.