### PR TITLE
#39 Allow merge flag only after approval

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -25,7 +25,6 @@ pull_request_rules:
       label:
         remove:
           - ready to merge
-
   - name: delete merged branches
     conditions:
       - merged
@@ -41,3 +40,13 @@ pull_request_rules:
       label:
         add:
           - WIP
+  - name: remove "ready to merge" label when pull is not approved
+    conditions:
+      - "#approved-reviews-by<1"
+      - label~=ready to merge
+    actions:
+      comment:
+        message: The "ready to merge" label can only be set after one pull request approval
+      label:
+        remove:
+          - ready to merge

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -42,7 +42,8 @@ pull_request_rules:
           - WIP
   - name: remove "ready to merge" label when pull is not approved
     conditions:
-      - "#approved-reviews-by<1"
+      - "#approved-reviews-by>0"
+      - "#changes-requested-reviews-by=0"
       - label~=ready to merge
     actions:
       comment:


### PR DESCRIPTION
# Issue #39

# Description

These changes prevent inadvertent merging, since the mergebot can only be activated via the label after an approve has been issued and no changes are requested anymore.

Documentation: https://doc.mergify.io/conditions.html#attribute-list