### PR TITLE
VUE-18 - Circular Progress Komponente zweifarbig

### DIFF
--- a/docs/storybook/ProgressRing.md
+++ b/docs/storybook/ProgressRing.md
@@ -1,0 +1,1 @@
+# ProgressRing

--- a/src/components/ProgressRing.unit.js
+++ b/src/components/ProgressRing.unit.js
@@ -1,0 +1,5 @@
+import ProgressRing from "./ProgressRing";
+
+describe("@components/ProgressRing", () => {
+	it(...isValidComponent(ProgressRing));
+});

--- a/src/components/ProgressRing.vue
+++ b/src/components/ProgressRing.vue
@@ -1,0 +1,92 @@
+<template>
+	<div class="container">
+		<span class="percent">{{ percent }}%</span>
+		<svg
+			class="progress-circle"
+			viewBox="0 0 106 106"
+			version="1.1"
+			xmlns="http://www.w3.org/2000/svg"
+			xmlns:xlink="http://www.w3.org/1999/xlink"
+		>
+			<g
+				id="Page-1"
+				stroke="none"
+				stroke-width="1"
+				fill="none"
+				fill-rule="evenodd"
+			>
+				<g id="ProgressBar" transform="translate(-17.000000, -17.000000)">
+					<circle id="oval" cx="70" cy="70" r="50"></circle>
+					<path
+						id="oval-copy"
+						class="path"
+						:stroke-dasharray="circle"
+						d="M70,120 C97.6142375,120 120,97.6142375 120,70 C120,42.3857625 97.6142375,20 70,20 C42.3857625,20 20,42.3857625 20,70 C20,97.6142375 42.3857625,120 70,120 Z"
+						fill-rule="nonzero"
+						transform="translate(70.000000, 70.000000) rotate(-125.000000) translate(-70.000000, -70.000000) "
+					></path>
+				</g>
+			</g>
+		</svg>
+	</div>
+</template>
+<script>
+export default {
+	props: {
+		percent: {
+			type: Number,
+			default: 0,
+			isComplete: false,
+		},
+	},
+	computed: {
+		circle() {
+			return (this.percent / 100) * 100 * Math.PI + ",9999";
+		},
+	},
+};
+</script>
+
+<style lang="scss" scoped>
+@import "@styles";
+
+$color-done: var(--color-primary);
+$color-todo: var(--color-gray);
+$color-complete: var(--color-success);
+
+#oval {
+	fill-rule: nonzero;
+	stroke: $color-todo;
+	stroke-width: 5;
+}
+
+#oval-copy {
+	stroke: $color-done;
+	stroke-width: 5;
+}
+
+.progress-circle {
+	width: 100%;
+	max-width: 70px;
+	max-height: 70px;
+	color: $color-todo;
+	transform: scaleX(-1) rotate(-55deg);
+}
+
+.percent {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	font-size: var(--text-lg);
+	transform: translate(-50%, -50%);
+}
+
+.container {
+	position: relative;
+	display: inline-block;
+}
+
+.path {
+	transition: 0.5s ease-in-out all;
+}
+</style>

--- a/stories/ProgressRing.stories.js
+++ b/stories/ProgressRing.stories.js
@@ -1,0 +1,22 @@
+import { storiesOf } from "@storybook/vue";
+
+import notes from "@docs/storybook/ProgressRing.md";
+import ProgressRing from "@components/ProgressRing";
+
+storiesOf("ProgressRing", module)
+	.addParameters({
+		notes,
+	})
+	.add("ProgressRing", () => ({
+		components: { ProgressRing },
+		data: () => ({
+			currentPercentage: 40,
+		}),
+		// methods: {
+		//     randomNumber() {
+		//       this.percent = Math.floor(Math.random() * (100 - 1 + 1)) + 1;
+		//     }
+		//   }
+
+		template: `<ProgressRing  :percent="currentPercentage"/>`,
+	}));


### PR DESCRIPTION
# Issue #{VUE-18}


## Description
Circular Progress Ring that receives percentage as prop. First version as described in Ticket: color-gray for the "not done" - part, color-primary for "done" parts. I used an svg example that I liked as a basis. 


## Screenshot

<img width="168" alt="Screenshot 2019-06-24 at 21 39 06" src="https://user-images.githubusercontent.com/43568777/60047379-dfde6e00-96c9-11e9-948a-bf6cbc2bccfa.png">
