### PR TITLE
quickfix scaling

### DIFF
--- a/src/themes/default/styles/utility/_typography.scss
+++ b/src/themes/default/styles/utility/_typography.scss
@@ -2,7 +2,6 @@
 	tab-size: 2;
 }
 
-html,
 body {
 	font-family: var(--font-primary);
 	font-size: var(--text-base-size);


### PR DESCRIPTION
## Description

- The pull before had an recursion defintion issue of the base font size. the text base size was defined as `1rem * x` and 1rem (font-size at the html element) was defines as text base size.
Should be fixed now.

