### PR TITLE
added vue-swatches package, including story in storybook

### DIFF
--- a/docs/storybook/ColorPicker.md
+++ b/docs/storybook/ColorPicker.md
@@ -1,0 +1,3 @@
+# ColorPicker
+
+`https://saintplay.github.io/vue-swatches`

--- a/package-lock.json
+++ b/package-lock.json
@@ -26381,6 +26381,11 @@
 				"svg-to-vue": "^0.4.0"
 			}
 		},
+		"vue-swatches": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/vue-swatches/-/vue-swatches-1.0.4.tgz",
+			"integrity": "sha512-bVzLpmwQU1sYgvQ0sD8jDzhFhAortJyc8KDogr0uC3SxzsPw/osfT0A28rhAQWsKYU1mpPXn6qk4khpbkgpbFw=="
+		},
 		"vue-template-compiler": {
 			"version": "2.6.10",
 			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
 		"vue-i18n": "^8.11.2",
 		"vue-loader": "^15.6.2",
 		"vue-multiselect": "^2.1.6",
-		"vue-ripple-directive": "^2.0.1"
+		"vue-ripple-directive": "^2.0.1",
+		"vue-swatches": "^1.0.4"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.4.3",

--- a/src/components/atoms/ColorPicker.stories.js
+++ b/src/components/atoms/ColorPicker.stories.js
@@ -1,0 +1,55 @@
+import { storiesOf } from "@storybook/vue";
+
+import notes from "@docs/storybook/ColorPicker.md";
+import ColorPicker from "@components/atoms/ColorPicker";
+
+storiesOf("Atoms|ColorPicker", module)
+	.addParameters({
+		notes,
+	})
+	.add("Color Picker Default", () => ({
+		components: { ColorPicker },
+		template: `<ColorPicker v-model="color"/>`,
+		methods: {},
+		data: () => ({
+			color: "",
+		}),
+	}))
+	.add("Color Picker Circles Inline", () => ({
+		components: { ColorPicker },
+		template: `<ColorPicker v-model="color" :colors="colors" shapes="circles" inline />`,
+		methods: {},
+		data: () => ({
+			color: "#00E5FF",
+			colors: [
+				"#ACACAC",
+				"#D4AF37",
+				"#00E5FF",
+				"#1DE9B6",
+				"#546E7A",
+				"#FFC400",
+				"#BCAAA4",
+				"#FF4081",
+				"#FFEE58",
+			],
+		}),
+	}))
+	.add("Color Picker Circles Popover", () => ({
+		components: { ColorPicker },
+		template: `<ColorPicker v-model="color" :colors="colors" row-length="3" shapes="circles" show-border popover-to="right"/>`,
+		methods: {},
+		data: () => ({
+			color: "#00E5FF",
+			colors: [
+				"#ACACAC",
+				"#D4AF37",
+				"#00E5FF",
+				"#1DE9B6",
+				"#546E7A",
+				"#FFC400",
+				"#BCAAA4",
+				"#FF4081",
+				"#FFEE58",
+			],
+		}),
+	}));

--- a/src/components/atoms/ColorPicker.unit.js
+++ b/src/components/atoms/ColorPicker.unit.js
@@ -1,0 +1,5 @@
+import ColorPicker from "./ColorPicker";
+
+describe("@components/ColorPicker", () => {
+	it(...isValidComponent(ColorPicker));
+});

--- a/src/components/atoms/ColorPicker.vue
+++ b/src/components/atoms/ColorPicker.vue
@@ -1,0 +1,40 @@
+<template>
+	<color-picker
+		v-bind="{ ...$attrs, ...$props }"
+		@input="$emit('input', $event)"
+	/>
+</template>
+
+<script>
+import ColorPicker from "vue-swatches";
+
+export default {
+	components: { ColorPicker },
+	props: {
+		value: {
+			type: String,
+			default: () => {
+				return "";
+			},
+		},
+		colors: {
+			type: Array,
+			default: () => {
+				return [
+					"#ACACAC",
+					"#D4AF37",
+					"#00E5FF",
+					"#1DE9B6",
+					"#546E7A",
+					"#FFC400",
+					"#BCAAA4",
+					"#FF4081",
+					"#FFEE58",
+				];
+			},
+		},
+	},
+};
+</script>
+
+<style src="vue-swatches/dist/vue-swatches.min.css"></style>

--- a/stories/misc.stories.js
+++ b/stories/misc.stories.js
@@ -12,11 +12,51 @@ import Searchbar from "@components/molecules/Searchbar";
 import PopupIcon from "@components/legacy/PopupIcon";
 import DemoBanner from "@components/legacy/DemoBanner";
 import PopupIconInitials from "@components/legacy/PopupIconInitials";
+import VueSwatchesColors from 'vue-swatches'
+import "vue-swatches/dist/vue-swatches.min.css"
 
 storiesOf("Misc", module)
 	.addParameters({
 		notes,
 	})
+	.add("Color Picker Pop Up", () => ({
+		components: { VueSwatchesColors },
+		data: () => ({
+		color: '#ACACAC',
+		colors: [
+			'#ACACAC',
+			'#D4AF37',
+			'#00E5FF',
+			'#1DE9B6',
+			'#546E7A',
+			'#FFC400',
+			'#BCAAA4',
+			'#FF4081',
+			'#FFEE58',
+		] }),
+		template: `
+		<VueSwatchesColors v-model="color" :colors="colors" row-length="3" shapes="circles" show-border popover-to="right"></VueSwatchesColors>
+		`,
+	}))
+	.add("Color Picker Inline", () => ({
+		components: { VueSwatchesColors },
+		data: () => ({
+		color: '#00E5FF',
+		colors: [
+			'#ACACAC',
+			'#D4AF37',
+			'#00E5FF',
+			'#1DE9B6',
+			'#546E7A',
+			'#FFC400',
+			'#BCAAA4',
+			'#FF4081',
+			'#FFEE58',
+		] }),
+		template: `
+		<VueSwatchesColors v-model="color" :colors="colors" shapes="circles" inline></VueSwatchesColors>
+		`,
+	}))
 	.add("Pulsing Dot", () => ({
 		components: { PulsatingDot },
 		template: `<PulsatingDot />`,

--- a/stories/misc.stories.js
+++ b/stories/misc.stories.js
@@ -12,8 +12,8 @@ import Searchbar from "@components/molecules/Searchbar";
 import PopupIcon from "@components/legacy/PopupIcon";
 import DemoBanner from "@components/legacy/DemoBanner";
 import PopupIconInitials from "@components/legacy/PopupIconInitials";
-import VueSwatchesColors from 'vue-swatches'
-import "vue-swatches/dist/vue-swatches.min.css"
+import VueSwatchesColors from "vue-swatches";
+import "vue-swatches/dist/vue-swatches.min.css";
 
 storiesOf("Misc", module)
 	.addParameters({
@@ -22,18 +22,19 @@ storiesOf("Misc", module)
 	.add("Color Picker Pop Up", () => ({
 		components: { VueSwatchesColors },
 		data: () => ({
-		color: '#ACACAC',
-		colors: [
-			'#ACACAC',
-			'#D4AF37',
-			'#00E5FF',
-			'#1DE9B6',
-			'#546E7A',
-			'#FFC400',
-			'#BCAAA4',
-			'#FF4081',
-			'#FFEE58',
-		] }),
+			color: "#ACACAC",
+			colors: [
+				"#ACACAC",
+				"#D4AF37",
+				"#00E5FF",
+				"#1DE9B6",
+				"#546E7A",
+				"#FFC400",
+				"#BCAAA4",
+				"#FF4081",
+				"#FFEE58",
+			],
+		}),
 		template: `
 		<VueSwatchesColors v-model="color" :colors="colors" row-length="3" shapes="circles" show-border popover-to="right"></VueSwatchesColors>
 		`,
@@ -41,18 +42,19 @@ storiesOf("Misc", module)
 	.add("Color Picker Inline", () => ({
 		components: { VueSwatchesColors },
 		data: () => ({
-		color: '#00E5FF',
-		colors: [
-			'#ACACAC',
-			'#D4AF37',
-			'#00E5FF',
-			'#1DE9B6',
-			'#546E7A',
-			'#FFC400',
-			'#BCAAA4',
-			'#FF4081',
-			'#FFEE58',
-		] }),
+			color: "#00E5FF",
+			colors: [
+				"#ACACAC",
+				"#D4AF37",
+				"#00E5FF",
+				"#1DE9B6",
+				"#546E7A",
+				"#FFC400",
+				"#BCAAA4",
+				"#FF4081",
+				"#FFEE58",
+			],
+		}),
 		template: `
 		<VueSwatchesColors v-model="color" :colors="colors" shapes="circles" inline></VueSwatchesColors>
 		`,

--- a/stories/misc.stories.js
+++ b/stories/misc.stories.js
@@ -12,53 +12,11 @@ import Searchbar from "@components/molecules/Searchbar";
 import PopupIcon from "@components/legacy/PopupIcon";
 import DemoBanner from "@components/legacy/DemoBanner";
 import PopupIconInitials from "@components/legacy/PopupIconInitials";
-import VueSwatchesColors from "vue-swatches";
-import "vue-swatches/dist/vue-swatches.min.css";
 
 storiesOf("Misc", module)
 	.addParameters({
 		notes,
 	})
-	.add("Color Picker Pop Up", () => ({
-		components: { VueSwatchesColors },
-		data: () => ({
-			color: "#ACACAC",
-			colors: [
-				"#ACACAC",
-				"#D4AF37",
-				"#00E5FF",
-				"#1DE9B6",
-				"#546E7A",
-				"#FFC400",
-				"#BCAAA4",
-				"#FF4081",
-				"#FFEE58",
-			],
-		}),
-		template: `
-		<VueSwatchesColors v-model="color" :colors="colors" row-length="3" shapes="circles" show-border popover-to="right"></VueSwatchesColors>
-		`,
-	}))
-	.add("Color Picker Inline", () => ({
-		components: { VueSwatchesColors },
-		data: () => ({
-			color: "#00E5FF",
-			colors: [
-				"#ACACAC",
-				"#D4AF37",
-				"#00E5FF",
-				"#1DE9B6",
-				"#546E7A",
-				"#FFC400",
-				"#BCAAA4",
-				"#FF4081",
-				"#FFEE58",
-			],
-		}),
-		template: `
-		<VueSwatchesColors v-model="color" :colors="colors" shapes="circles" inline></VueSwatchesColors>
-		`,
-	}))
 	.add("Pulsing Dot", () => ({
 		components: { PulsatingDot },
 		template: `<PulsatingDot />`,


### PR DESCRIPTION
<!--
please use:
- `#{issue Number}` (#12) for github issues
- and `[Vue-{issue Number}](https://ticketsystem.schul-cloud.org/browse/VUE-18)` for issues from our ticketsystem
-->

# Issue: VUE-56
https://ticketsystem.schul-cloud.org/browse/VUE-56

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://ticketsystem.schul-cloud.org/

-->

## Description

- added external vue-swatches component
- needs to be extended for accesiblity
- aria label by is already an open issue and in work
- maybe we want to contribute https://saintplay.github.io/vue-swatches/
- component is relatively powerful, enables custom styling, different modes of display, e. g. https://saintplay.github.io/vue-swatches/#sub-inline-custom-u-i

## Screenshot

![Screen Shot 2019-10-23 at 11 47 59](https://user-images.githubusercontent.com/7567881/67380684-fec31300-f58a-11e9-991c-317c52b58391.png)
![Screen Shot 2019-10-23 at 11 48 03](https://user-images.githubusercontent.com/7567881/67380704-05518a80-f58b-11e9-8952-7dd40e2c3dab.png)