### PR TITLE
cherrypick menubutton hotfix from #301

### DIFF
--- a/src/components/legacy/TheTopBar.vue
+++ b/src/components/legacy/TheTopBar.vue
@@ -183,6 +183,9 @@ export default {
 			}
 
 			.menu-button {
+				position: fixed;
+				top: 0;
+				left: 0;
 				transform: rotate(90deg);
 			}
 		}


### PR DESCRIPTION
# Description

- menu button is now visible and you can close the menu

## Screenshot

### Before
![image](https://user-images.githubusercontent.com/22987140/69038574-6766a980-09ea-11ea-8c67-670a7d159981.png)

### After
![image](https://user-images.githubusercontent.com/22987140/69038603-6fbee480-09ea-11ea-948e-63da3880b213.png)
