### PR TITLE
Always Upload integration-test report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,9 @@ jobs:
         - echo "skipping install"
       before_cache:
         - mkdir -p node_modules
+      after_script:
+        - npm i -g @adrianjost/report-viewer
+        - rv-upload -F **/reports/**/*.html
     # Lint
     - script: npm run lint:ci
       name: "lint"


### PR DESCRIPTION
# Issue

currently reports are only uploaded after success (because if there is an error the integration test fails before the upload script)

## Description

- moved tthe upload script to travis where we have more control over it