### PR TITLE
validate params.id to be a valid mongoId

### DIFF
--- a/src/pages/news/_id/index.vue
+++ b/src/pages/news/_id/index.vue
@@ -39,6 +39,9 @@ import "dayjs/locale/de";
 dayjs.locale("de");
 
 export default {
+	validate({ params }) {
+		return /^[a-z0-9]{24}$/.test(params.id);
+	},
 	async asyncData({ store, params }) {
 		return {
 			news: await store.dispatch("news/get", params.id),


### PR DESCRIPTION
# Issue: Validate News ID to be a valid MongoID

## Description

- if the ID is not valid, the page will not get rendered and handled as a 404 => redirect to legacy client
