### PR TITLE
hotfix/staging-deploy - add $SYSTEM to api url

### DIFF
--- a/deploy/compose-client_brb.dummy
+++ b/deploy/compose-client_brb.dummy
@@ -16,7 +16,7 @@ services:
       - NODE_ENV=production
       - TZ=Europe/Berlin
       - LEGACY_CLIENT_URL=http://client:3100
-      - API_URL=https://api.test.schul-cloud.org
+      - API_URL=https://api.$SYSTEM.schul-cloud.org
       - SENTRY_DSN=https://18a7cbf1a7ef427ebcfc38429d18ba40@sentry.schul-cloud.dev/7
       # FEATURE TOGGLES
       - FEATURE_TEAMS_ENABLED=true

--- a/deploy/compose-client_default.dummy
+++ b/deploy/compose-client_default.dummy
@@ -16,7 +16,7 @@ services:
       - NODE_ENV=production
       - TZ=Europe/Berlin
       - LEGACY_CLIENT_URL=http://client:3100
-      - API_URL=https://api.test.schul-cloud.org
+      - API_URL=https://api.$SYSTEM.schul-cloud.org
       - SENTRY_DSN=https://18a7cbf1a7ef427ebcfc38429d18ba40@sentry.schul-cloud.dev/7
       # FEATURE TOGGLES
       - FEATURE_TEAMS_ENABLED=true

--- a/deploy/compose-client_n21.dummy
+++ b/deploy/compose-client_n21.dummy
@@ -16,7 +16,7 @@ services:
       - NODE_ENV=production
       - TZ=Europe/Berlin
       - LEGACY_CLIENT_URL=http://client:3100
-      - API_URL=https://api.test.schul-cloud.org
+      - API_URL=https://api.$SYSTEM.schul-cloud.org
       - SENTRY_DSN=https://18a7cbf1a7ef427ebcfc38429d18ba40@sentry.schul-cloud.dev/7
       # FEATURE TOGGLES
       - FEATURE_TEAMS_ENABLED=true

--- a/deploy/compose-client_open.dummy
+++ b/deploy/compose-client_open.dummy
@@ -16,7 +16,7 @@ services:
       - NODE_ENV=production
       - TZ=Europe/Berlin
       - LEGACY_CLIENT_URL=http://client:3100
-      - API_URL=https://api.test.schul-cloud.org
+      - API_URL=https://api.$SYSTEM.schul-cloud.org
       - SENTRY_DSN=https://18a7cbf1a7ef427ebcfc38429d18ba40@sentry.schul-cloud.dev/7
       # FEATURE TOGGLES
       - FEATURE_TEAMS_ENABLED=true


### PR DESCRIPTION
# Issue

- users where logged out in staging because the API was not reachable. (was referring to test instead of staging and the authentication cookie was now availble for this subdomain)

## Description

- added the environment as a variable to all the compose files
