### PR TITLE
enable jest/prefer strict equal rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,6 @@ module.exports = {
 				// to reduce the number of errors we disable some rules for now.
 				// But they should be removed here ASAP.
 				// https://github.com/jest-community/eslint-plugin-jest
-				"jest/prefer-strict-equal": "off",
 				"jest/no-truthy-falsy": "off",
 				"jest/no-test-return-statement": "off",
 				"jest/require-top-level-describe": "off",

--- a/src/components/base/BaseLink.unit.js
+++ b/src/components/base/BaseLink.unit.js
@@ -34,7 +34,7 @@ describe("@components/BaseLink", () => {
 			},
 		});
 		expect(element.outerHTML).toContain("https://schul-cloud.org");
-		expect(element.tagName).toEqual("A");
+		expect(element.tagName).toStrictEqual("A");
 	});
 
 	it("renders NuxtLink-tag for internal :to links", () => {
@@ -44,8 +44,8 @@ describe("@components/BaseLink", () => {
 				to: "/news",
 			},
 		});
-		expect(element.getAttribute("to")).toEqual("/news");
-		expect(element.tagName).not.toEqual("A");
+		expect(element.getAttribute("to")).toStrictEqual("/news");
+		expect(element.tagName).not.toStrictEqual("A");
 	});
 
 	it("renders NuxtLink-tag for internal links by name", () => {
@@ -55,7 +55,7 @@ describe("@components/BaseLink", () => {
 				name: "news",
 			},
 		});
-		expect(element.tagName).not.toEqual("A");
+		expect(element.tagName).not.toStrictEqual("A");
 	});
 
 	/*

--- a/src/components/base/BaseSelect.unit.js
+++ b/src/components/base/BaseSelect.unit.js
@@ -51,7 +51,7 @@ describe("@components/BaseSelect", () => {
 				value: [],
 			},
 		});
-		expect(wrapper.find(MultiSelect).attributes()["aria-label"]).toEqual(
+		expect(wrapper.find(MultiSelect).attributes()["aria-label"]).toStrictEqual(
 			"label"
 		);
 	});
@@ -132,12 +132,12 @@ describe("@components/BaseSelect", () => {
 		expect(multiSelect.attributes("deselectlabel")).toBe("deselectLabel");
 		expect(multiSelect.attributes("multiple")).toBeTruthy();
 		expect(multiSelect.attributes("label")).toBe("optionLabel");
-		expect(multiSelect.props("options")).toEqual(options);
+		expect(multiSelect.props("options")).toStrictEqual(options);
 		expect(multiSelect.attributes("placeholder")).toBe("placeholder");
 		expect(multiSelect.attributes("selectlabel")).toBe("selectLabel");
 		expect(multiSelect.attributes("selectedlabel")).toBe("selectedLabel");
 		expect(multiSelect.attributes("trackby")).toBe("id");
-		expect(multiSelect.props("value")).toEqual(options);
+		expect(multiSelect.props("value")).toStrictEqual(options);
 	});
 
 	it("emits events", () => {
@@ -151,12 +151,14 @@ describe("@components/BaseSelect", () => {
 		});
 		const multiSelect = wrapper.find("multi-select-stub");
 		multiSelect.vm.$emit("select", "select");
-		expect(wrapper.emitted().select).toEqual([["select"]]);
+		expect(wrapper.emitted().select).toStrictEqual([["select"]]);
 		multiSelect.vm.$emit("input", "input");
-		expect(wrapper.emitted().input).toEqual([["input"]]);
+		expect(wrapper.emitted().input).toStrictEqual([["input"]]);
 		multiSelect.vm.$emit("search-change", "search-change");
-		expect(wrapper.emitted()["search-change"]).toEqual([["search-change"]]);
+		expect(wrapper.emitted()["search-change"]).toStrictEqual([
+			["search-change"],
+		]);
 		multiSelect.vm.$emit("tag", "tag");
-		expect(wrapper.emitted().tag).toEqual([["tag"]]);
+		expect(wrapper.emitted().tag).toStrictEqual([["tag"]]);
 	});
 });

--- a/src/components/base/BaseSpinner.unit.js
+++ b/src/components/base/BaseSpinner.unit.js
@@ -9,7 +9,7 @@ describe("@components/BaseSpinner", () => {
 				label: "label",
 			},
 		});
-		expect(element.getAttribute("aria-label")).toEqual("label");
+		expect(element.getAttribute("aria-label")).toStrictEqual("label");
 	});
 
 	it("can change its size", () => {
@@ -18,10 +18,10 @@ describe("@components/BaseSpinner", () => {
 				size: "large",
 			},
 		});
-		expect(wrapper.find(".spinner").attributes("height")).toEqual("60");
-		expect(wrapper.find(".spinner").attributes("width")).toEqual("60");
-		expect(wrapper.find(".circle").attributes("r")).toEqual("14");
-		expect(wrapper.find(".circle").attributes("cx")).toEqual("15");
-		expect(wrapper.find(".circle").attributes("cy")).toEqual("15");
+		expect(wrapper.find(".spinner").attributes("height")).toStrictEqual("60");
+		expect(wrapper.find(".spinner").attributes("width")).toStrictEqual("60");
+		expect(wrapper.find(".circle").attributes("r")).toStrictEqual("14");
+		expect(wrapper.find(".circle").attributes("cx")).toStrictEqual("15");
+		expect(wrapper.find(".circle").attributes("cy")).toStrictEqual("15");
 	});
 });

--- a/src/components/base/BaseTable/BaseTable.unit.js
+++ b/src/components/base/BaseTable/BaseTable.unit.js
@@ -281,7 +281,7 @@ describe("@components/BaseTable", () => {
 	it("updates its filters when filtersSelected property is changed", () => {
 		const wrapper = getShallowWrapper({ filterable: true });
 
-		expect(wrapper.vm.newFiltersSelected).toEqual([]);
+		expect(wrapper.vm.newFiltersSelected).toStrictEqual([]);
 
 		const newFilters = [
 			{
@@ -297,7 +297,7 @@ describe("@components/BaseTable", () => {
 		];
 
 		wrapper.setProps({ filtersSelected: newFilters });
-		expect(wrapper.vm.newFiltersSelected).toEqual(newFilters);
+		expect(wrapper.vm.newFiltersSelected).toStrictEqual(newFilters);
 	});
 
 	it("allows to set filters", () => {
@@ -311,7 +311,9 @@ describe("@components/BaseTable", () => {
 
 			openFilterModal(wrapper);
 			submitFilterModal(wrapper);
-			expect(wrapper.vm.newFiltersSelected[0].value).toEqual(filter.value);
+			expect(wrapper.vm.newFiltersSelected[0].value).toStrictEqual(
+				filter.value
+			);
 			expect(wrapper.emitted()["update:filters-selected"]).toHaveLength(1);
 			let expectedTagLabel;
 			if (["number", "text"].includes(filter.type)) {
@@ -328,7 +330,7 @@ describe("@components/BaseTable", () => {
 			} else if (filter.type === "select") {
 				expectedTagLabel = `${filter.label}: ${filter.value[0].value}`;
 			}
-			expect(wrapper.emitted()["update:filters-selected"][0]).toEqual([
+			expect(wrapper.emitted()["update:filters-selected"][0]).toStrictEqual([
 				[
 					{
 						...filter,
@@ -353,7 +355,9 @@ describe("@components/BaseTable", () => {
 			wrapper.find(".multiselect__tag-icon").trigger("mousedown");
 
 			expect(wrapper.emitted()["update:filters-selected"]).toHaveLength(2);
-			expect(wrapper.emitted()["update:filters-selected"][1]).toEqual([[]]);
+			expect(wrapper.emitted()["update:filters-selected"][1]).toStrictEqual([
+				[],
+			]);
 
 			openFilterModal(wrapper);
 			submitFilterModal(wrapper);
@@ -363,7 +367,9 @@ describe("@components/BaseTable", () => {
 			filterMenu.vm.select(filter);
 
 			expect(wrapper.emitted()["update:filters-selected"]).toHaveLength(4);
-			expect(wrapper.emitted()["update:filters-selected"][1]).toEqual([[]]);
+			expect(wrapper.emitted()["update:filters-selected"][1]).toStrictEqual([
+				[],
+			]);
 		});
 	});
 
@@ -381,12 +387,12 @@ describe("@components/BaseTable", () => {
 						openFilterModal(wrapper);
 						selectMatchingType(wrapper, matchingType.value);
 						submitFilterModal(wrapper);
-						expect(wrapper.vm.newFiltersSelected[0].matchingType.value).toEqual(
-							matchingType.value
-						);
-						expect(wrapper.vm.newFiltersSelected[0].matchingType.label).toEqual(
-							matchingType.label
-						);
+						expect(
+							wrapper.vm.newFiltersSelected[0].matchingType.value
+						).toStrictEqual(matchingType.value);
+						expect(
+							wrapper.vm.newFiltersSelected[0].matchingType.label
+						).toStrictEqual(matchingType.label);
 						expect(wrapper.emitted()["update:filters-selected"]).toHaveLength(
 							index + 1
 						);
@@ -401,17 +407,17 @@ describe("@components/BaseTable", () => {
 								}
 							);
 						}
-						expect(wrapper.emitted()["update:filters-selected"][index]).toEqual(
+						expect(
+							wrapper.emitted()["update:filters-selected"][index]
+						).toStrictEqual([
 							[
-								[
-									{
-										...filter,
-										matchingType,
-										tagLabel: `${filter.label} ${matchingType.label} ${expectedFilterValue}`,
-									},
-								],
-							]
-						);
+								{
+									...filter,
+									matchingType,
+									tagLabel: `${filter.label} ${matchingType.label} ${expectedFilterValue}`,
+								},
+							],
+						]);
 					}
 				);
 			}
@@ -483,26 +489,26 @@ describe("@components/BaseTable", () => {
 
 						submitFilterModal(wrapper);
 
-						expect(wrapper.vm.newFiltersSelected[0].value).toEqual(
+						expect(wrapper.vm.newFiltersSelected[0].value).toStrictEqual(
 							newFilterValue
 						);
 						expect(wrapper.emitted()["update:filters-selected"]).toHaveLength(
 							index + 1
 						);
-						expect(wrapper.emitted()["update:filters-selected"][index]).toEqual(
+						expect(
+							wrapper.emitted()["update:filters-selected"][index]
+						).toStrictEqual([
 							[
-								[
-									{
-										...filter,
-										matchingType,
-										value: newFilterValue,
-										tagLabel: `${filter.label} ${matchingType.label} ${expectedFilterValue}`,
-									},
-								],
-							]
-						);
+								{
+									...filter,
+									matchingType,
+									value: newFilterValue,
+									tagLabel: `${filter.label} ${matchingType.label} ${expectedFilterValue}`,
+								},
+							],
+						]);
 						const tag = wrapper.find(".multiselect__tag span");
-						expect(tag.text()).toEqual(
+						expect(tag.text()).toStrictEqual(
 							`${filter.label} ${matchingType.label} ${expectedFilterValue}`
 						);
 					}
@@ -512,21 +518,25 @@ describe("@components/BaseTable", () => {
 					const multiSelectInput = wrapper.find(".multiselect__input");
 					multiSelectInput.setValue(newFilterValue);
 					multiSelectInput.trigger("keypress.enter");
-					expect(wrapper.vm.newFiltersSelected[0].value).toEqual(
+					expect(wrapper.vm.newFiltersSelected[0].value).toStrictEqual(
 						newFilterValue
 					);
 					expect(wrapper.emitted()["update:filters-selected"]).toHaveLength(1);
-					expect(wrapper.emitted()["update:filters-selected"][0]).toEqual([
+					expect(wrapper.emitted()["update:filters-selected"][0]).toStrictEqual(
 						[
-							{
-								...filter,
-								value: newFilterValue,
-								tagLabel: `Volltextsuche nach: ${newFilterValue}`,
-							},
-						],
-					]);
+							[
+								{
+									...filter,
+									value: newFilterValue,
+									tagLabel: `Volltextsuche nach: ${newFilterValue}`,
+								},
+							],
+						]
+					);
 					const tag = wrapper.find(".multiselect__tag span");
-					expect(tag.text()).toEqual(`Volltextsuche nach: ${newFilterValue}`);
+					expect(tag.text()).toStrictEqual(
+						`Volltextsuche nach: ${newFilterValue}`
+					);
 				}
 				if (filter.type === "select") {
 					const filterValue = filter.value.filter(
@@ -539,27 +549,31 @@ describe("@components/BaseTable", () => {
 					checkbox.setChecked();
 
 					submitFilterModal(wrapper);
-					expect(wrapper.vm.newFiltersSelected[0].value[0].checked).toEqual(
-						true
-					);
+					expect(
+						wrapper.vm.newFiltersSelected[0].value[0].checked
+					).toStrictEqual(true);
 					expect(wrapper.emitted()["update:filters-selected"]).toHaveLength(1);
-					expect(wrapper.emitted()["update:filters-selected"][0]).toEqual([
+					expect(wrapper.emitted()["update:filters-selected"][0]).toStrictEqual(
 						[
-							{
-								...filter,
-								value: [
-									{
-										...filter.value[0],
-										value: newFilterValue,
-										checked: true,
-									},
-								],
-								tagLabel: `${filter.label}: ${newFilterValue}`,
-							},
-						],
-					]);
+							[
+								{
+									...filter,
+									value: [
+										{
+											...filter.value[0],
+											value: newFilterValue,
+											checked: true,
+										},
+									],
+									tagLabel: `${filter.label}: ${newFilterValue}`,
+								},
+							],
+						]
+					);
 					const tag = wrapper.find(".multiselect__tag span");
-					expect(tag.text()).toEqual(`${filter.label}: ${newFilterValue}`);
+					expect(tag.text()).toStrictEqual(
+						`${filter.label}: ${newFilterValue}`
+					);
 				}
 			}
 		});
@@ -589,13 +603,15 @@ describe("@components/BaseTable", () => {
 
 		expect(wrapper.find("tbody tr").classes()).toContain("selected");
 		expect(wrapper.vm.allRowsOfCurrentPageSelected).toBe(false);
-		expect(wrapper.emitted()["update:selected-rows"][0]).toEqual([[data[0]]]);
+		expect(wrapper.emitted()["update:selected-rows"][0]).toStrictEqual([
+			[data[0]],
+		]);
 
 		rowSelection.setChecked(false);
 
 		expect(wrapper.find("tbody tr").classes()).not.toContain("selected");
 		expect(wrapper.vm.allRowsOfCurrentPageSelected).toBe(false);
-		expect(wrapper.emitted()["update:selected-rows"][1]).toEqual([[]]);
+		expect(wrapper.emitted()["update:selected-rows"][1]).toStrictEqual([[]]);
 	});
 
 	it("allows to select and unselect all rows of current page", () => {
@@ -610,29 +626,29 @@ describe("@components/BaseTable", () => {
 		expect(wrapper.vm.allRowsOfCurrentPageSelected).toBe(true);
 
 		expect(wrapper.emitted()["update:selected-rows"]).toHaveLength(1);
-		expect(wrapper.emitted()["update:selected-rows"][0]).toEqual([
+		expect(wrapper.emitted()["update:selected-rows"][0]).toStrictEqual([
 			data.slice(0, 2),
 		]);
 
 		expect(wrapper.emitted()["all-rows-of-current-page-selected"]).toHaveLength(
 			1
 		);
-		expect(wrapper.emitted()["all-rows-of-current-page-selected"][0]).toEqual([
-			data.slice(0, 2),
-		]);
+		expect(
+			wrapper.emitted()["all-rows-of-current-page-selected"][0]
+		).toStrictEqual([data.slice(0, 2)]);
 
 		allRowsSelection.setChecked(false);
 		expect(wrapper.vm.allRowsOfCurrentPageSelected).toBe(false);
 
 		expect(wrapper.emitted()["update:selected-rows"]).toHaveLength(2);
-		expect(wrapper.emitted()["update:selected-rows"][1]).toEqual([[]]);
+		expect(wrapper.emitted()["update:selected-rows"][1]).toStrictEqual([[]]);
 
 		expect(wrapper.emitted()["all-rows-of-current-page-selected"]).toHaveLength(
 			2
 		);
-		expect(wrapper.emitted()["all-rows-of-current-page-selected"][1]).toEqual([
-			[],
-		]);
+		expect(
+			wrapper.emitted()["all-rows-of-current-page-selected"][1]
+		).toStrictEqual([[]]);
 	});
 
 	it("allows to select and unselect all rows of current page manually", () => {
@@ -677,10 +693,10 @@ describe("@components/BaseTable", () => {
 		expect(wrapper.vm.allRowsOfAllPagesSelected).toBe(true);
 
 		expect(wrapper.emitted()["update:selected-rows"]).toHaveLength(2);
-		expect(wrapper.emitted()["update:selected-rows"][1]).toEqual([data]);
+		expect(wrapper.emitted()["update:selected-rows"][1]).toStrictEqual([data]);
 
 		expect(wrapper.emitted()["all-rows-selected"]).toHaveLength(1);
-		expect(wrapper.emitted()["all-rows-selected"][0]).toEqual([data]);
+		expect(wrapper.emitted()["all-rows-selected"][0]).toStrictEqual([data]);
 	});
 
 	it("can trigger an action on selected rows", () => {
@@ -700,10 +716,10 @@ describe("@components/BaseTable", () => {
 		expect(testAction).toHaveBeenCalled();
 
 		expect(wrapper.emitted()["update:selected-rows"]).toHaveLength(2);
-		expect(wrapper.emitted()["update:selected-rows"][1]).toEqual([[]]);
+		expect(wrapper.emitted()["update:selected-rows"][1]).toStrictEqual([[]]);
 
 		expect(wrapper.emitted()["all-rows-selected"]).toHaveLength(1);
-		expect(wrapper.emitted()["all-rows-selected"][0]).toEqual([[]]);
+		expect(wrapper.emitted()["all-rows-selected"][0]).toStrictEqual([[]]);
 	});
 
 	it("does not change row selection when new rows are added", () => {

--- a/src/components/legacy/TheTopBar.unit.js
+++ b/src/components/legacy/TheTopBar.unit.js
@@ -41,7 +41,7 @@ describe("@components/legacy/TheTopBar", () => {
 		expect(wrapper.findAll("popup-icon-stub")).toHaveLength(1);
 		expect(wrapper.findAll("button")).toHaveLength(1);
 		wrapper.find("button").trigger("click");
-		expect(wrapper.emitted("action")[0]).toEqual(["light-camera"]);
+		expect(wrapper.emitted("action")[0]).toStrictEqual(["light-camera"]);
 		expect(wrapper.findAll(".item")).toHaveLength(4);
 	});
 	it("can switch to fullscreen mode", () => {
@@ -52,7 +52,7 @@ describe("@components/legacy/TheTopBar", () => {
 		});
 
 		wrapper.find(".fullscreen-button").trigger("click");
-		expect(wrapper.emitted().action[0]).toEqual(["fullscreen"]);
+		expect(wrapper.emitted().action[0]).toStrictEqual(["fullscreen"]);
 
 		expect(wrapper.findAll(".item")).toHaveLength(0);
 		expect(wrapper.findAll(".top-sidebar")).toHaveLength(0);

--- a/src/components/molecules/TextEditor.unit.js
+++ b/src/components/molecules/TextEditor.unit.js
@@ -35,12 +35,16 @@ describe("@components/BaseTextarea", () => {
 		const after = `<p>after</p>`;
 		const wrapper = await getMock({ data: () => ({ content: before }) });
 		const contentContainer = wrapper.find(`[contenteditable]`);
-		expect(contentContainer.html()).toEqual(expect.stringContaining(before));
+		expect(contentContainer.html()).toStrictEqual(
+			expect.stringContaining(before)
+		);
 		wrapper.setData({ content: after });
-		expect(contentContainer.html()).toEqual(
+		expect(contentContainer.html()).toStrictEqual(
 			expect.not.stringContaining(before)
 		);
-		expect(contentContainer.html()).toEqual(expect.stringContaining(after));
+		expect(contentContainer.html()).toStrictEqual(
+			expect.stringContaining(after)
+		);
 	});
 
 	it("showImagePrompt calls callback with src", async () => {
@@ -157,6 +161,6 @@ describe("@components/BaseTextarea", () => {
 
 		expect(undoStub.called).toBe(false);
 		expect(toastStub.called).toBe(false);
-		expect(wrapper.emitted("update")[0][0]).toEqual(validContent);
+		expect(wrapper.emitted("update")[0][0]).toStrictEqual(validContent);
 	});
 });

--- a/src/components/organisms/DropdownMenu.unit.js
+++ b/src/components/organisms/DropdownMenu.unit.js
@@ -60,6 +60,6 @@ describe("@components/organisms/DropdownMenu", () => {
 			},
 		});
 		wrapper.find("li").trigger("click");
-		expect(wrapper.emitted().input).toEqual([[item]]);
+		expect(wrapper.emitted().input).toStrictEqual([[item]]);
 	});
 });

--- a/src/components/organisms/FormNews.unit.js
+++ b/src/components/organisms/FormNews.unit.js
@@ -69,9 +69,9 @@ describe("@components/FormNews", () => {
 				news: validNews,
 			},
 		});
-		expect(wrapper.vm.data.date.date).toEqual(validNewsDate.date);
-		expect(wrapper.vm.data.date.time).toEqual(validNewsDate.time);
-		expect(wrapper.vm.publishDate).toEqual(validNews.displayAt);
+		expect(wrapper.vm.data.date.date).toStrictEqual(validNewsDate.date);
+		expect(wrapper.vm.data.date.time).toStrictEqual(validNewsDate.time);
+		expect(wrapper.vm.publishDate).toStrictEqual(validNews.displayAt);
 	});
 
 	describe("create", () => {

--- a/src/components/organisms/Pagination.unit.js
+++ b/src/components/organisms/Pagination.unit.js
@@ -54,14 +54,14 @@ describe("@components/organisms/Pagination", () => {
 		const wrapper = getFirstPageWrapper();
 		const nextPageLink = wrapper.findAll(".pagination-link").at(1);
 		nextPageLink.trigger("click");
-		expect(wrapper.emitted()["update:current-page"]).toEqual([[2]]);
+		expect(wrapper.emitted()["update:current-page"]).toStrictEqual([[2]]);
 	});
 
 	it("emits update:current-page when previous page link is clicked", () => {
 		const wrapper = getLastPageWrapper();
 		const previousPageLink = wrapper.find(".pagination-link");
 		previousPageLink.trigger("click");
-		expect(wrapper.emitted()["update:current-page"]).toEqual([[1]]);
+		expect(wrapper.emitted()["update:current-page"]).toStrictEqual([[1]]);
 	});
 
 	it("emits update:per-page when new perPage value is selected", () => {
@@ -74,7 +74,7 @@ describe("@components/organisms/Pagination", () => {
 		const perPageSelect = wrapper.find(MultiSelect);
 		const secondOption = perPageSelect.vm.options[2];
 		perPageSelect.vm.select(secondOption);
-		expect(wrapper.emitted()["update:per-page"]).toEqual([
+		expect(wrapper.emitted()["update:per-page"]).toStrictEqual([
 			[secondOption.value],
 		]);
 	});


### PR DESCRIPTION
## Description

- depends on #440
- enables `jest/prefer strict equal` rule. 
- All changes where done by the fix option of eslint

**Why?**
https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-strict-equal.md
