### PR TITLE
enable jest/no-truthy-falsy rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,6 @@ module.exports = {
 				// to reduce the number of errors we disable some rules for now.
 				// But they should be removed here ASAP.
 				// https://github.com/jest-community/eslint-plugin-jest
-				"jest/no-truthy-falsy": "off",
 				"jest/no-test-return-statement": "off",
 				"jest/require-top-level-describe": "off",
 				"jest/consistent-test-it": [

--- a/src/components/base/BaseInput/BaseInputCheckbox.unit.js
+++ b/src/components/base/BaseInput/BaseInputCheckbox.unit.js
@@ -12,7 +12,7 @@ describe("@components/BaseInputCheckbox", () => {
 					vmodel: true,
 				},
 			});
-			expect(wrapper.find("input[type='checkbox']").exists()).toBeTruthy();
+			expect(wrapper.find("input[type='checkbox']").exists()).toBe(true);
 		});
 	});
 
@@ -53,10 +53,10 @@ describe("@components/BaseInputCheckbox", () => {
 		const valueBefore = wrapper.vm.value.length;
 		input.setChecked(true);
 		expect(wrapper.vm.value).toHaveLength(valueBefore + 1);
-		expect(wrapper.vm.value.includes(testValue)).toBeTruthy();
+		expect(wrapper.vm.value).toContain(testValue);
 		input.setChecked(false);
 		expect(wrapper.vm.value).toHaveLength(valueBefore);
-		expect(wrapper.vm.value.includes(testValue)).toBeFalsy();
+		expect(wrapper.vm.value).not.toContain(testValue);
 	});
 
 	it(`shows checkmark only when it is checked`, () => {

--- a/src/components/base/BaseInput/BaseInputHidden.unit.js
+++ b/src/components/base/BaseInput/BaseInputHidden.unit.js
@@ -13,7 +13,7 @@ describe("@components/BaseInputHidden", () => {
 			});
 			const input = wrapper.find(`input`);
 			expect(input.element.value).toBe(mockText);
-			expect(input.isVisible()).toBeFalsy();
+			expect(input.isVisible()).toBe(false);
 		});
 	});
 });

--- a/src/components/base/BaseInput/BaseInputRadio.unit.js
+++ b/src/components/base/BaseInput/BaseInputRadio.unit.js
@@ -11,7 +11,7 @@ describe("@components/BaseInputRadio", () => {
 				vmodel: "test",
 			},
 		});
-		expect(wrapper.find("input[type='radio']").exists()).toBeTruthy();
+		expect(wrapper.find("input[type='radio']").exists()).toBe(true);
 	});
 
 	it(`input updates v-model`, () => {
@@ -43,10 +43,10 @@ describe("@components/BaseInputRadio", () => {
 			components: { BaseInput },
 		});
 
-		expect(wrapper.find("input[value=b]:checked")).toBeTruthy();
+		expect(wrapper.find("input[value=b]:checked").exists()).toBe(true);
 		wrapper.setData({ value: "a" });
-		expect(wrapper.find("input[value=a]:checked")).toBeTruthy();
+		expect(wrapper.find("input[value=a]:checked").exists()).toBe(true);
 		wrapper.setData({ value: "b" });
-		expect(wrapper.find("input[value=b]:checked")).toBeTruthy();
+		expect(wrapper.find("input[value=b]:checked").exists()).toBe(true);
 	});
 });

--- a/src/components/base/BaseSelect.unit.js
+++ b/src/components/base/BaseSelect.unit.js
@@ -128,16 +128,16 @@ describe("@components/BaseSelect", () => {
 			},
 		});
 		const multiSelect = wrapper.find("multi-select-stub");
-		expect(multiSelect.attributes("closeonselect")).toBeTruthy();
+		expect(multiSelect.attributes("closeonselect")).toBe("true");
 		expect(multiSelect.attributes("deselectlabel")).toBe("deselectLabel");
-		expect(multiSelect.attributes("multiple")).toBeTruthy();
+		expect(multiSelect.attributes("multiple")).toBe("true");
 		expect(multiSelect.attributes("label")).toBe("optionLabel");
-		expect(multiSelect.props("options")).toStrictEqual(options);
+		expect(multiSelect.props("options")).toStrictEqual(options); // TODO: this doesn't seem testing anything except the render method
 		expect(multiSelect.attributes("placeholder")).toBe("placeholder");
 		expect(multiSelect.attributes("selectlabel")).toBe("selectLabel");
 		expect(multiSelect.attributes("selectedlabel")).toBe("selectedLabel");
 		expect(multiSelect.attributes("trackby")).toBe("id");
-		expect(multiSelect.props("value")).toStrictEqual(options);
+		expect(multiSelect.props("value")).toStrictEqual(options); // TODO: this doesn't seem testing anything except the render method
 	});
 
 	it("emits events", () => {

--- a/src/components/base/BaseTextarea.unit.js
+++ b/src/components/base/BaseTextarea.unit.js
@@ -12,8 +12,7 @@ describe("@components/BaseTextarea", () => {
 
 	it("textarea has label", () => {
 		const wrapper = getMock();
-		expect(wrapper.find(".label").element.innerHTML.includes("test"))
-			.toBeTruthy;
+		expect(wrapper.find(".label").element.innerHTML).toContain("test");
 	});
 
 	it("changing the element's value, updates the v-model", () => {

--- a/src/components/base/BaseVideo.unit.js
+++ b/src/components/base/BaseVideo.unit.js
@@ -15,7 +15,7 @@ describe("@components/BaseVideo", () => {
 			sources: mockVideos,
 		});
 		mockVideos.forEach((video) => {
-			expect(wrapper.find(`[src="${video.src}"]`)).toBeTruthy();
+			expect(wrapper.find(`[src="${video.src}"]`).exists()).toBe(true);
 		});
 	});
 
@@ -34,7 +34,7 @@ describe("@components/BaseVideo", () => {
 			tracks: mockTracks,
 		});
 		mockVideos.forEach((track) => {
-			expect(wrapper.find(`[src="${track.src}"]`)).toBeTruthy();
+			expect(wrapper.find(`[src="${track.src}"]`).exists()).toBe(true);
 		});
 	});
 
@@ -43,7 +43,7 @@ describe("@components/BaseVideo", () => {
 		const wrapper = getVideoplayer({
 			sources: mockVideos,
 		});
-		expect(wrapper.contains(`video[controls]`)).toBeTruthy();
+		expect(wrapper.contains(`video[controls]`)).toBe(true);
 	});
 
 	it("can render without controls", () => {
@@ -52,6 +52,6 @@ describe("@components/BaseVideo", () => {
 			sources: mockVideos,
 			noControls: true,
 		});
-		expect(wrapper.contains("video[controls]")).toBeFalsy();
+		expect(wrapper.contains("video[controls]")).toBe(false);
 	});
 });

--- a/src/components/molecules/TextEditor.unit.js
+++ b/src/components/molecules/TextEditor.unit.js
@@ -139,7 +139,7 @@ describe("@components/BaseTextarea", () => {
 
 		expect(undoStub.called).toBe(true);
 		expect(toastStub.called).toBe(true);
-		expect(wrapper.emitted().update).toBeFalsy();
+		expect(wrapper.emitted("update")).toBeUndefined();
 	});
 
 	it("emits update for valid content", async () => {


### PR DESCRIPTION
## Description

- depends on #441
- enables `jest/no-truthy-falsy` rule. 

**Why?**
https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-truthy-falsy.md