### PR TITLE
feature/auto dependency update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,7 +23,7 @@ pull_request_rules:
           - ready to merge
   - name: ask to resolve conflict
     conditions:
-      - conflicts
+      - conflict
     actions:
       label:
         add:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -42,7 +42,15 @@ pull_request_rules:
       merge:
         method: squash
         strict: true
-  - name: auto merge passing Dependabot pull requests
+  - name: auto merge passing Dependabot (Preview) pull requests
+    conditions:
+      - author=dependabot-preview[bot]
+      - label~=dependencies
+    actions:
+      merge:
+        method: squash
+        strict: true
+  - name: auto merge passing Dependabot (GitHub) pull requests
     conditions:
       - author=dependabot[bot]
       - label~=dependencies

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -30,6 +30,7 @@ pull_request_rules:
           - has conflicts
       comment:
         message: This pull request is now in conflicts. Could you fix it? 🙏
+
   #######################
   # AUTO MERGING
   #######################
@@ -56,6 +57,7 @@ pull_request_rules:
       merge:
         method: merge
         strict: true
+
   #######################
   # CLEANUP AFTER MERGE
   #######################

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,42 +1,7 @@
 pull_request_rules:
-  - name: automatic merging when label is set
-    conditions:
-      - label!=WIP
-      - label!=waiting
-      - label=ready to merge
-      - status-success~=Travis CI
-
-      # make sure the complete matrix passed
-      - status-success~=lint
-      - -status-neutral~=lint
-      - -status-failure~=lint
-      - status-success~=test-unit
-      - -status-neutral~=test-unit
-      - -status-failure~=test-unit
-      # - status-success~=build
-      # - -status-neutral~=build
-      # - -status-failure~=build
-
-      - status-success=Mergeable
-      - status-success=codecov/project
-    actions:
-      merge:
-        method: merge
-        strict: true
-  - name: remove ready to merge when merged
-    conditions:
-      - merged
-      - label=ready to merge
-    actions:
-      label:
-        remove:
-          - ready to merge
-  - name: delete merged branches
-    conditions:
-      - merged
-      - label!=WIP
-    actions:
-      delete_head_branch: {}
+  #######################
+  # MERGE PRECONDITIONS
+  #######################
   - name: add WIP label when WIP is in title
     conditions:
       - title~=WIP
@@ -48,12 +13,65 @@ pull_request_rules:
           - WIP
   - name: remove "ready to merge" label when pull is not approved
     conditions:
-      - "#approved-reviews-by=0"
+      - -status-success~=pullapprove
       - label~=ready to merge
-      - -merged
     actions:
       comment:
-        message: The "ready to merge" label can only be set after one pull request approval
+        message: The "ready to merge" label can only be set on approved pull request
       label:
         remove:
           - ready to merge
+  - name: ask to resolve conflict
+    conditions:
+      - conflicts
+    actions:
+      label:
+        add:
+          - has conflicts
+      comment:
+        message: This pull request is now in conflicts. Could you fix it? 🙏
+  #######################
+  # AUTO MERGING
+  #######################
+  - name: auto merge passing Greenkeeper pull requests
+    conditions:
+      - author=greenkeeper[bot]
+      - label~=greenkeeper
+    actions:
+      merge:
+        method: squash
+        strict: true
+  - name: auto merge passing Dependabot pull requests
+    conditions:
+      - author=dependabot[bot]
+      - label~=dependencies
+    actions:
+      merge:
+        method: squash
+        strict: true
+  - name: auto merge when ready to merge label is set
+    conditions:
+      - label=ready to merge
+    actions:
+      merge:
+        method: merge
+        strict: true
+  #######################
+  # CLEANUP AFTER MERGE
+  #######################
+  - name: remove ready to merge when merged
+    conditions:
+      - merged
+      - label=ready to merge
+    actions:
+      label:
+        add:
+          - auto_merged
+        remove:
+          - ready to merge
+  - name: delete merged branches
+    conditions:
+      - merged
+      - label!=WIP
+    actions:
+      delete_head_branch: {}

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,58 @@
+version: 3
+
+pullapprove_conditions:
+  - condition: "'WIP' not in labels"
+    unmet_status: pending
+    explanation: "Work in progress"
+
+  # not tested yet
+  # - condition: "'*lint*' in statuses.succeeded"
+  #   unmet_status: failure
+  #   explanation: "Linter must pass before review starts"
+  # - condition: "'*test*' in statuses.succeeded"
+  #   unmet_status: failure
+  #   explanation: "Linter must pass before review starts"
+
+groups:
+  ###############################
+  # GENERAL REQUEST FOR REVIEW
+  ###############################
+  nuxt-core:
+    conditions:
+      # not created by bot
+      - " author.username != 'dependabot-preview'"
+      - " author.username != 'greenkeeper'"
+    reviews:
+      required: 1 # 1 approval from this group is required
+      request: 2 # 2 reviews requests will be sent at a time
+      request_order: shuffle # reviewers will be chosen in a random order
+    reviewers:
+      teams:
+        - VueCoreDevs
+    labels:
+      pending: "waiting for review"
+      rejected: "WIP"
+
+  ###############################
+  # LABEL SPECIFIC REQUESTS
+  ###############################
+  integrathors:
+    conditions:
+      - "'IntegraTHORs' in labels"
+    reviews:
+      required: 1 # 1 approval from this group are required
+      request: 2 # 2 reviews requests will be sent at a time
+      request_order: shuffle # reviewers will be chosen in a random order
+    reviewers:
+      teams:
+        - integrathors
+  loki:
+    conditions:
+      - "'Loki' in labels"
+    reviews:
+      required: 1 # 1 approval from this group are required
+      request: 2 # 2 reviews requests will be sent at a time
+      request_order: shuffle # reviewers will be chosen in a random order
+    reviewers:
+      teams:
+        - loki

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -32,27 +32,26 @@ groups:
     labels:
       pending: "waiting for review"
       rejected: "WIP"
-
   ###############################
   # LABEL SPECIFIC REQUESTS
   ###############################
-  integrathors:
-    conditions:
-      - "'IntegraTHORs' in labels"
-    reviews:
-      required: 1 # 1 approval from this group are required
-      request: 2 # 2 reviews requests will be sent at a time
-      request_order: shuffle # reviewers will be chosen in a random order
-    reviewers:
-      teams:
-        - integrathors
-  loki:
-    conditions:
-      - "'Loki' in labels"
-    reviews:
-      required: 1 # 1 approval from this group are required
-      request: 2 # 2 reviews requests will be sent at a time
-      request_order: shuffle # reviewers will be chosen in a random order
-    reviewers:
-      teams:
-        - loki
+  # integrathors:
+  #   conditions:
+  #     - "'IntegraTHORs' in labels"
+  #   reviews:
+  #     required: 1 # 1 approval from this group are required
+  #     request: 2 # 2 reviews requests will be sent at a time
+  #     request_order: shuffle # reviewers will be chosen in a random order
+  #   reviewers:
+  #     teams:
+  #       - integrathors
+  # loki:
+  #   conditions:
+  #     - "'Loki' in labels"
+  #   reviews:
+  #     required: 1 # 1 approval from this group are required
+  #     request: 2 # 2 reviews requests will be sent at a time
+  #     request_order: shuffle # reviewers will be chosen in a random order
+  #   reviewers:
+  #     teams:
+  #       - loki

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -20,7 +20,7 @@ groups:
   nuxt-core:
     conditions:
       # not created by a bot
-      - "'dependabot-preview' not in author.username"
+      - "'dependabot' not in author.username"
       - "'greenkeeper' not in author.username"
     reviews:
       required: 1 # 1 approval from this group is required

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -19,9 +19,9 @@ groups:
   ###############################
   nuxt-core:
     conditions:
-      # not created by bot
-      - " author.username != 'dependabot-preview'"
-      - " author.username != 'greenkeeper'"
+      # not created by a bot
+      - "'dependabot-preview' in author"
+      - "'greenkeeper' in author"
     reviews:
       required: 1 # 1 approval from this group is required
       request: 2 # 2 reviews requests will be sent at a time

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -20,8 +20,8 @@ groups:
   nuxt-core:
     conditions:
       # not created by a bot
-      - "'dependabot-preview' in author"
-      - "'greenkeeper' in author"
+      - "'dependabot-preview' not in author.username"
+      - "'greenkeeper' not in author.username"
     reviews:
       required: 1 # 1 approval from this group is required
       request: 2 # 2 reviews requests will be sent at a time


### PR DESCRIPTION
# Issue

updating dependencies or checking open pulls of those is tedious and costs a lot of working time.

## Description

> this Pull aims to automate most dependency updates by configuring mergify and skip the required pull approval for pulls by bots

- if pull is from dependabot or greenkeeper pullapprove will not require any review, otherwise someone from the VueCoreDev Team need to approve before merging
  - we need pullapprove to disable the requirement of reviews for certain PR's, GitHubs Branch protection feature does not support this usecase.
- if PR is from dependabot or greenkeeper and all required status checks are passing, mergify will merge the PR (even without any approval)

## TODO After Merge
- [ ] disable review requirement in branch protection settings for the develop branch
- [ ] enable pullapprove success as a requirement for merging into develop