### PR TITLE
fix scroll on checkbox toggle

### DIFF
--- a/src/components/base/BaseInput/BaseInputCheckbox.vue
+++ b/src/components/base/BaseInput/BaseInputCheckbox.vue
@@ -83,6 +83,7 @@ export default {
 @import "@styles";
 
 .wrapper {
+	position: relative;
 	display: inline-flex;
 	align-items: center;
 }


### PR DESCRIPTION
# Issue: [SC-3398](https://ticketsystem.schul-cloud.org/browse/SC-3398)

## Description

the issue was caused because of our visually-hidden class. This class moved the actual checkbox input to the very top left of the browser window. Whenever you now toggled the input by clicking on the table you focused it and the browser tried to scroll the checkbox into your viewport. The fix is pretty simple, just add a position:relative to the wrapping visable label so the visually-hidden class only moved the input to the very top left of the label itself.

## How to test

Open the Storybook DataTable with 50 items per page. Toggle any checkbox at the bottom of the table. Your scroll position should not change anymore.