### PR TITLE
feature/SC-3434 use round material icons

### DIFF
--- a/src/components/base/BaseIcon.vue
+++ b/src/components/base/BaseIcon.vue
@@ -44,7 +44,7 @@ export default {
 				}
 				if (this.source === "material") {
 					// src: https://material.io/tools/icons/?style=baseline
-					icon = require(`!!vue-svg-loader?{"svgo":{"plugins":[{"removeDimensions": true }, {"removeViewBox":false}]}}!material-icons-svg/icons/baseline-${this.icon}-24px.svg`);
+					icon = require(`!!vue-svg-loader?{"svgo":{"plugins":[{"removeDimensions": true }, {"removeViewBox":false}]}}!material-icons-svg/icons/round-${this.icon}-24px.svg`);
 				}
 				return icon.default;
 			} catch (error) {


### PR DESCRIPTION
# Issue: [SC-3434 ](https://ticketsystem.schul-cloud.org/browse/SC-3434 )

## Description

- [from](https://material.io/resources/icons/?style=baseline) => [to](https://material.io/resources/icons/?style=round)

## Screenshot
### before
![image](https://user-images.githubusercontent.com/22987140/75143597-92514f80-56f5-11ea-9155-0de33c869632.png)
### after
![image](https://user-images.githubusercontent.com/22987140/75143602-97160380-56f5-11ea-8d1d-43213bb1190f.png)
