### PR TITLE
bugfix Context Menu in LernStore

### DIFF
--- a/src/components/base/BaseButton.scss
+++ b/src/components/base/BaseButton.scss
@@ -122,8 +122,9 @@
 	background: var(--button-background);
 	border: 1px solid transparent;
 	border-radius: var(--radius-sm);
-	transition: all var(--duration-transition-medium)
-		cubic-bezier(0.23, 1, 0.32, 1);
+	transition-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
+	transition-duration: var(--duration-transition-medium);
+	transition-property: background, box-shadow;
 
 	&:not(.is-icon) > * {
 		// removes margin from icon button

--- a/src/components/base/BaseButton.scss
+++ b/src/components/base/BaseButton.scss
@@ -1,6 +1,6 @@
 @import "@styles";
 
-.button {
+button {
 	// typo
 	--button-font-weight: var(--font-weight-bold);
 	--button-line-height: var(--line-height-md);

--- a/src/components/molecules/ContextMenu.vue
+++ b/src/components/molecules/ContextMenu.vue
@@ -15,8 +15,8 @@
 				class="context-menu__button"
 				role="menuitem"
 				@click="emitEvent(action.event, action.arguments)"
-				@keydown.up="focusPrev(index)"
-				@keydown.down="focusNext(index)"
+				@keydown.up.prevent="focusPrev(index)"
+				@keydown.down.prevent="focusNext(index)"
 			>
 				<base-icon
 					v-if="action.icon"
@@ -218,7 +218,7 @@ export default {
 	background-color: var(--color-white);
 	border-radius: var(--radius-sm);
 	box-shadow: var(--shadow-m);
-	:hover {
+	> :hover {
 		background-color: var(--color-gray-light);
 	}
 	&__button {


### PR DESCRIPTION
# Issue: Context menu looked strange on /content page

The Issue only exists at /content, not in Storybook because of different order of CSS imports. We should investigate this further later on. For now, this should fix the issue.

## Description

The Problem existed because of the undefined order of CSS imports. To overwrite styles we need to be more specific therefore I:

- reduced the specificity of BaseButton CSS to make it easier to overwrite styles
https://cdn-media-1.freecodecamp.org/images/1*wH2JSH_fw4oiAH2eqTg4qA.png

## Screenshot

**http://localhost:4000/content/**
![image](https://user-images.githubusercontent.com/22987140/75169513-fccfb300-5728-11ea-96d0-2334a03209f7.png)

