### PR TITLE
SC-3930 - fix navigation error for import page

### DIFF
--- a/src/components/molecules/FabIcon.vue
+++ b/src/components/molecules/FabIcon.vue
@@ -146,7 +146,9 @@ export default {
 			if (!this.noAutoClose) {
 				this.isOpen = false;
 			}
-			this.$emit(action.event, action.arguments);
+			if (action.event) {
+				this.$emit(action.event, action.arguments);
+			}
 		},
 	},
 };


### PR DESCRIPTION
# Issue: [SC-3930 ](https://ticketsystem.schul-cloud.org/browse/SC-3930 )

## Description

- der FAB hat fälschlicherweise immer versucht ein event zu werden, was natürlich fehlschlägt, wenn statt einem event ein link übergeben wird.
