### PR TITLE
Quickfix - fix auto_merged label rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -94,6 +94,9 @@ pull_request_rules:
       merge:
         method: squash
         strict: smart
+      label:
+        add:
+          - auto_merged
   - name: auto merge passing Dependabot pull requests
     conditions:
       # match dependabot[bot] and dependabot-preview[bot]
@@ -103,6 +106,9 @@ pull_request_rules:
       merge:
         method: squash
         strict: smart
+      label:
+        add:
+          - auto_merged
   - name: auto merge when ready to merge label is set
     conditions:
       - label=ready to merge
@@ -110,6 +116,9 @@ pull_request_rules:
       merge:
         method: merge
         strict: smart
+      label:
+        add:
+          - auto_merged
 
   #######################
   # CLEANUP AFTER MERGE
@@ -120,8 +129,6 @@ pull_request_rules:
       - label=ready to merge
     actions:
       label:
-        add:
-          - auto_merged
         remove:
           - ready to merge
   - name: delete merged branches


### PR DESCRIPTION
# Description

- the auto_merged label was applied wrongly to manually merged PRs when they had the ready to merge label but where merged manual

## Links to Tickets or other pull requests

<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.schul-cloud.org/browse/SC-????
-->

## Changes

the label will now be set during the merge process, not afterwards

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
