### PR TITLE
Update pullapprove to the group of gernal

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,39 +1,30 @@
 version: 3
 
 pullapprove_conditions:
-  - condition: "'WIP' not in labels"
-    unmet_status: pending
-    explanation: "Work in progress"
+- condition: "'WIP' not in labels"
+  unmet_status: pending
+  explanation: "Work in progress"
+- condition: "'- [ ]' not in body"
+  unmet_status: failure
+  explanation: "Please finish all the required checklist tasks"
 
-  # not tested yet
-  # - condition: "'*lint*' in statuses.succeeded"
-  #   unmet_status: failure
-  #   explanation: "Linter must pass before review starts"
-  # - condition: "'*test*' in statuses.succeeded"
-  #   unmet_status: failure
-  #   explanation: "Linter must pass before review starts"
+
+notifications:
+- when: pull_request.opened
+  comment: |
+    Hey @{{ author }}, thanks for the PR! The review will start once
+    the tests, CI checks and PR requirements (see checklist in your PR) have passed.
+- when: pullapprove.approved
+  if: "author_association == 'CONTRIBUTOR'"
+  comment: "The review is completed. Thanks @{{ author }}, we'll take it from here."
 
 groups:
   ###############################
   # GENERAL REQUEST FOR REVIEW
   ###############################
-  sc-admins:
-    conditions:
-      # not created by a bot
-      - "'schul-cloud-bot' not in author.username"
-      - "'dependabot' not in author.username"
-      - "'greenkeeper' not in author.username"
+  general:
     reviews:
       required: 1 # 1 approval from this group is required
     reviewers:
       teams:
-        - sc-admins
-  devops:
-    conditions:
-      - "'*deploy.sh' in files or '.build/*' in files or 'deploy/*' in files" # only review specific, deployment relevant files
-    reviewers:
-      teams:
-        - devops
-    reviews:
-      required: 1 # number of approvals required from this group
-      author_value: 1 # if author of pr is in team, no additional review required
+        - general


### PR DESCRIPTION
# Short Description
Next step on the new group plann for github.
Change the group to gerneral who is requeierd by pullaporve to approve pull request.

## Links to Ticket and related Pull-Requests
hpi-schul-cloud/schulcloud-server#3145
hpi-schul-cloud/schulcloud-client#2700
hpi-schul-cloud/end-to-end-tests#361

## Changes
Change the group to gerneral who is requeierd by pullaporve to approve pull request.

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
