### PR TITLE
BC-11592 - reload board after copying

### DIFF
--- a/src/modules/feature/board/board/Board.vue
+++ b/src/modules/feature/board/board/Board.vue
@@ -187,17 +187,6 @@ watch(board, async () => {
 
 const route = useRoute();
 
-watch(
-	() => route.params.id,
-	() => {
-		const boardId = Array.isArray(route.params.id) ? route.params.id[0] : route.params.id;
-		if (boardId !== props.boardId) {
-			boardStore.fetchBoardRequest({ boardId });
-		}
-	},
-	{ immediate: true }
-);
-
 useBodyScrolling();
 
 const isBoardVisible = computed(() => board.value?.isVisible);
@@ -419,7 +408,10 @@ const onCopyBoard = async () => {
 
 	await copy({ id: props.boardId, type: CopyParamsTypeEnum.ColumnBoard });
 	const copyId = copyModule.getCopyResult?.id;
-	router.push({ name: "boards-id", params: { id: copyId } });
+	if (copyId) {
+		boardStore.fetchBoardRequest({ boardId: copyId });
+		router.push({ name: "boards-id", params: { id: copyId } });
+	}
 };
 
 const shareModule = injectStrict(SHARE_MODULE_KEY);


### PR DESCRIPTION
# Short Description
When a colummBoard was copied, the copied board should be loaded.

## Links to Ticket and related Pull-Requests
BC-11592

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)
- [x] Cypress: Every new feature has suitable Cypress tests implemented

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
