### PR TITLE
BC-11596 - fix logging out from SVS and external system at the same time

### DIFF
--- a/src/modules/data/application/application.store.ts
+++ b/src/modules/data/application/application.store.ts
@@ -69,7 +69,6 @@ export const useAppStore = defineStore("applicationStore", () => {
 
 	const clearUserSession = () => {
 		localStorage.clear();
-		sessionStorage.clear();
 		delete $axios.defaults.headers.common["Authorization"];
 		close();
 	};

--- a/src/modules/data/application/application.store.ts
+++ b/src/modules/data/application/application.store.ts
@@ -62,7 +62,7 @@ export const useAppStore = defineStore("applicationStore", () => {
 	};
 
 	const logout = (redirectUrl = "/logout") => {
-		sendLogout();
+		// sendLogout();
 		clearUserSession();
 		globalThis.location.replace(redirectUrl);
 	};
@@ -70,7 +70,7 @@ export const useAppStore = defineStore("applicationStore", () => {
 	const clearUserSession = () => {
 		localStorage.clear();
 		delete $axios.defaults.headers.common["Authorization"];
-		close();
+		// close();
 	};
 
 	const externalLogout = () => logout("/logout/external");

--- a/src/modules/data/application/application.store.ts
+++ b/src/modules/data/application/application.store.ts
@@ -62,7 +62,7 @@ export const useAppStore = defineStore("applicationStore", () => {
 	};
 
 	const logout = (redirectUrl = "/logout") => {
-		// sendLogout();
+		sendLogout();
 		clearUserSession();
 		globalThis.location.replace(redirectUrl);
 	};
@@ -70,7 +70,7 @@ export const useAppStore = defineStore("applicationStore", () => {
 	const clearUserSession = () => {
 		localStorage.clear();
 		delete $axios.defaults.headers.common["Authorization"];
-		// close();
+		close();
 	};
 
 	const externalLogout = () => logout("/logout/external");

--- a/src/modules/data/application/application.store.ts
+++ b/src/modules/data/application/application.store.ts
@@ -69,6 +69,7 @@ export const useAppStore = defineStore("applicationStore", () => {
 
 	const clearUserSession = () => {
 		localStorage.clear();
+		sessionStorage.clear();
 		delete $axios.defaults.headers.common["Authorization"];
 		close();
 	};

--- a/src/modules/feature/auto-logout/autoLogout.composable.ts
+++ b/src/modules/feature/auto-logout/autoLogout.composable.ts
@@ -122,10 +122,18 @@ export const useAutoLogout = () => {
 		sessionState.value = SessionState.Expired;
 		setTime(0);
 		stopTimer();
-		showDialog.value = true;
-		notifyError("feature-autoLogout.message.error.401", false);
 		useAppStore().clearUserSession();
-		await logoutUserSilently();
+		setTimeout(() => {
+			showDialog.value = true;
+			logoutUserSilently();
+		}, 5000);
+	};
+
+	const setClosedState = () => {
+		stopTimer();
+		sessionState.value = SessionState.Closed;
+		setTime(0);
+		showDialog.value = false;
 	};
 
 	const setErrorState = () => {
@@ -139,6 +147,7 @@ export const useAutoLogout = () => {
 		[SessionState.AboutToExpire]: setAboutToExpireState,
 		[SessionState.Extended]: setExtendedState,
 		[SessionState.Expired]: setExpiredState,
+		[SessionState.Closed]: setClosedState,
 		[SessionState.Error]: setErrorState,
 	};
 
@@ -164,7 +173,7 @@ export const useAutoLogout = () => {
 
 	const logoutUserSilently = async () => {
 		try {
-			await fetch("/logout");
+			// await fetch("/logout");
 		} catch (error) {
 			logger.error("Unexpected error during silent logout:", error);
 		}

--- a/src/modules/feature/auto-logout/autoLogout.composable.ts
+++ b/src/modules/feature/auto-logout/autoLogout.composable.ts
@@ -173,7 +173,7 @@ export const useAutoLogout = () => {
 
 	const logoutUserSilently = async () => {
 		try {
-			// await fetch("/logout");
+			await fetch("/logout");
 		} catch (error) {
 			logger.error("Unexpected error during silent logout:", error);
 		}

--- a/src/modules/feature/auto-logout/autoLogout.composable.ts
+++ b/src/modules/feature/auto-logout/autoLogout.composable.ts
@@ -123,16 +123,14 @@ export const useAutoLogout = () => {
 		setTime(0);
 		stopTimer();
 		useAppStore().clearUserSession();
-		setTimeout(() => {
-			showDialog.value = true;
-			logoutUserSilently();
-		}, 5000);
+		showDialog.value = true;
+		logoutUserSilently();
 	};
 
 	const setClosedState = () => {
-		stopTimer();
 		sessionState.value = SessionState.Closed;
 		setTime(0);
+		stopTimer();
 		showDialog.value = false;
 	};
 

--- a/src/modules/feature/auto-logout/autoLogout.composable.unit.ts
+++ b/src/modules/feature/auto-logout/autoLogout.composable.unit.ts
@@ -343,17 +343,6 @@ describe("useAutoLogout", () => {
 		});
 
 		describe("when session expires", () => {
-			it("should show error notification", async () => {
-				const options = { jwtTtl: 3, showWarningTime: 2 };
-				setupAndCreateSession(options);
-
-				await advanceTimersBySeconds(4);
-
-				expect(useNotificationStore().notify).toHaveBeenCalledWith(
-					expect.objectContaining({ status: "error", autoClose: false })
-				);
-			});
-
 			it("should show the dialog", async () => {
 				const options = { jwtTtl: 3, showWarningTime: 2 };
 				const { showDialog } = setupAndCreateSession(options);

--- a/src/modules/feature/auto-logout/autoLogout.composable.unit.ts
+++ b/src/modules/feature/auto-logout/autoLogout.composable.unit.ts
@@ -12,7 +12,7 @@ import { createTestingPinia } from "@pinia/testing";
 import { SessionState } from "@util-broadcast-channel";
 import { logger } from "@util-logger";
 import { flushPromises } from "@vue/test-utils";
-import { setActivePinia } from "pinia";
+import { Mocked, setActivePinia } from "pinia";
 
 vi.mock("@/utils/api", () => ({
 	$axios: {
@@ -22,7 +22,14 @@ vi.mock("@/utils/api", () => ({
 }));
 globalThis.fetch = vi.fn();
 
-const broadcastChannelMock = mockBroadcastChannel();
+let messageHandler: ((event: MessageEvent) => void) | null = null;
+let broadcastChannelMock: Mocked<BroadcastChannel>;
+
+const simulateIncomingMessage = (data: string) => {
+	if (messageHandler) {
+		messageHandler({ data } as MessageEvent);
+	}
+};
 
 vi.useFakeTimers();
 vi.spyOn(globalThis, "setInterval");
@@ -44,6 +51,14 @@ describe("useAutoLogout", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.clearAllTimers();
+		messageHandler = null;
+		broadcastChannelMock = mockBroadcastChannel({
+			addEventListener: vi.fn().mockImplementation((type: string, listener: EventListenerOrEventListenerObject) => {
+				if (type === "message" && typeof listener === "function") {
+					messageHandler = listener as (event: MessageEvent) => void;
+				}
+			}),
+		});
 	});
 
 	afterEach(() => {
@@ -425,6 +440,64 @@ describe("useAutoLogout", () => {
 
 				expect(broadcastChannelMock.postMessage).toHaveBeenCalledWith(expect.stringContaining("expired:"));
 			});
+		});
+
+		describe("when receiving state from another tab", () => {
+			it("should set sessionState to 'Closed' when receiving closed state", async () => {
+				const { createSession, sessionState } = setup();
+				createSession();
+				await flushPromises();
+
+				// Simulate receiving closed state from another tab (e.g., due to logout)
+				simulateIncomingMessage("closed:0");
+				await flushPromises();
+
+				expect(sessionState.value).toBe(SessionState.Closed);
+			});
+
+			it("should hide dialog and reset timer when receiving closed state", async () => {
+				const { createSession, showDialog, remainingTimeInSeconds } = setup();
+				createSession();
+				await flushPromises();
+
+				// Simulate receiving closed state from another tab
+				simulateIncomingMessage("closed:0");
+				await flushPromises();
+
+				expect(showDialog.value).toBe(false);
+				expect(remainingTimeInSeconds.value).toBe(0);
+			});
+
+			it("should not change state when receiving the same state via broadcast", async () => {
+				const { createSession, sessionState } = setup();
+				createSession();
+				await flushPromises();
+
+				expect(sessionState.value).toBe(SessionState.Started);
+
+				// Simulate receiving the same state from another tab
+				simulateIncomingMessage("started:100");
+				await flushPromises();
+
+				// State should still be Started (no duplicate processing)
+				expect(sessionState.value).toBe(SessionState.Started);
+			});
+		});
+	});
+
+	describe("logoutUserSilently error handling", () => {
+		it("should log error when fetch fails during silent logout", async () => {
+			const options = { jwtTtl: 2, showWarningTime: 1 };
+			const loggerSpy = vi.spyOn(logger, "error").mockImplementation(vi.fn());
+			const fetchError = new Error("Network error");
+			vi.mocked(globalThis.fetch).mockRejectedValueOnce(fetchError);
+
+			setupAndCreateSession(options);
+
+			// Let the session expire to trigger logoutUserSilently
+			await advanceTimersBySeconds(3);
+
+			expect(loggerSpy).toHaveBeenCalledWith("Unexpected error during silent logout:", fetchError);
 		});
 	});
 });

--- a/src/modules/util/broadcast-channel/sessionBroadcast.composable.ts
+++ b/src/modules/util/broadcast-channel/sessionBroadcast.composable.ts
@@ -46,6 +46,7 @@ const JWT_TIMER_ENDPOINT = "/v1/accounts/jwtTimer";
 // these constants are also used inside of the schulcloud-client to communicate logouts between both application parts
 const BROADCAST_CHANNEL_NAME = "user-session-channel";
 const BROADCAST_MESSAGE_LOGOUT = "logout";
+const BROADCAST_MESSAGE_EXPIRED = "expired";
 
 const isJwtExpired = ref(false);
 
@@ -82,9 +83,16 @@ export const useSessionBroadcast = (options?: SessionBroadcastOptions) => {
 					if (onLogoutReceived) {
 						onLogoutReceived();
 					} else if (setState) {
-						setState(SessionState.Expired);
+						setState(SessionState.Closed);
 					}
 					return;
+				}
+
+				if (message === BROADCAST_MESSAGE_EXPIRED) {
+					setJwtExpired(true);
+					if (setState) {
+						setState(SessionState.Expired);
+					}
 				}
 
 				if (typeof message === "string" && message.includes(":")) {

--- a/src/modules/util/broadcast-channel/sessionBroadcast.composable.unit.ts
+++ b/src/modules/util/broadcast-channel/sessionBroadcast.composable.unit.ts
@@ -145,6 +145,55 @@ describe("useSessionBroadcast", () => {
 				expect(setTime).toHaveBeenCalledWith(500);
 				expect(setState).not.toHaveBeenCalled();
 			});
+
+			it("should ignore messages without colon separator", async () => {
+				const { setState, setTime, sendStateAndTime } = setup();
+
+				sendStateAndTime(SessionState.Started, 100);
+
+				simulateIncomingMessage("invalidmessage");
+				await flushPromises();
+
+				expect(setState).not.toHaveBeenCalled();
+				expect(setTime).not.toHaveBeenCalled();
+			});
+
+			it("should update time with 0 when no time callbacks are provided", async () => {
+				const setState = vi.fn();
+				const { sendStateAndTime } = useSessionBroadcast({ setState });
+
+				sendStateAndTime(SessionState.Started, 100);
+
+				simulateIncomingMessage("extended:200");
+				await flushPromises();
+
+				expect(setState).toHaveBeenCalledWith(SessionState.Extended);
+			});
+		});
+
+		describe("when receiving an 'expired' message", () => {
+			it("should call setState with Expired and set jwt expired", async () => {
+				const { setState, sendStateAndTime, isJwtExpired } = setup();
+
+				sendStateAndTime(SessionState.Started, 100);
+
+				simulateIncomingMessage("expired");
+				await flushPromises();
+
+				expect(setState).toHaveBeenCalledWith(SessionState.Expired);
+				expect(isJwtExpired.value).toBe(true);
+			});
+
+			it("should work without setState callback", async () => {
+				const { sendLogout, isJwtExpired } = useSessionBroadcast();
+
+				sendLogout();
+
+				simulateIncomingMessage("expired");
+				await flushPromises();
+
+				expect(isJwtExpired.value).toBe(true);
+			});
 		});
 	});
 
@@ -344,6 +393,52 @@ describe("useSessionBroadcast", () => {
 			await handleUnauthorizedError(axiosError);
 
 			expect(isJwtExpired.value).toBe(true);
+		});
+
+		it("should handle missing response data gracefully", async () => {
+			const { handleUnauthorizedError, isJwtExpired } = useSessionBroadcast();
+			const { AxiosError, default: axios } = await import("axios");
+			const axiosError = new AxiosError("error", "401", undefined, undefined, {
+				status: HttpStatusCode.Unauthorized,
+			} as never);
+
+			const mockAxiosInstance = {
+				defaults: { baseURL: "" },
+				get: vi.fn().mockResolvedValue({ data: null }),
+			};
+			vi.spyOn(axios, "create").mockReturnValue(mockAxiosInstance as never);
+
+			await handleUnauthorizedError(axiosError);
+
+			expect(isJwtExpired.value).toBe(true);
+		});
+	});
+
+	describe("BroadcastChannel unavailable", () => {
+		it("should work when BroadcastChannel is undefined", () => {
+			vi.stubGlobal("BroadcastChannel", undefined);
+
+			const { sendLogout, sendStateAndTime } = useSessionBroadcast();
+
+			// Should not throw errors
+			expect(() => {
+				sendLogout();
+				sendStateAndTime(SessionState.Started, 100);
+			}).not.toThrow();
+
+			vi.unstubAllGlobals();
+		});
+	});
+
+	describe("channel reuse", () => {
+		it("should reuse the same BroadcastChannel instance", () => {
+			const { sendLogout, sendStateAndTime } = useSessionBroadcast();
+
+			sendLogout();
+			sendStateAndTime(SessionState.Started, 100);
+
+			// Both calls should use the same channel instance
+			expect(broadcastChannelMock.postMessage).toHaveBeenCalledTimes(2);
 		});
 	});
 });

--- a/src/modules/util/broadcast-channel/sessionBroadcast.composable.unit.ts
+++ b/src/modules/util/broadcast-channel/sessionBroadcast.composable.unit.ts
@@ -106,7 +106,7 @@ describe("useSessionBroadcast", () => {
 				simulateIncomingMessage("logout");
 				await flushPromises();
 
-				expect(setState).toHaveBeenCalledWith(SessionState.Expired);
+				expect(setState).toHaveBeenCalledWith(SessionState.Closed);
 			});
 		});
 

--- a/src/modules/util/broadcast-channel/types.ts
+++ b/src/modules/util/broadcast-channel/types.ts
@@ -4,4 +4,5 @@ export enum SessionState {
 	Expired = "expired",
 	Error = "error",
 	Started = "started",
+	Closed = "closed",
 }


### PR DESCRIPTION
# Short Description
When chosing to logout from SVS and another external identity-provider, the second sometimes fails.

## Links to Ticket and related Pull-Requests
BC-11596
https://github.com/hpi-schul-cloud/schulcloud-client/pull/3806

## Changes
- revert some changes from other ticket (related to autologout)


## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)
- [x] Cypress: Every new feature has suitable Cypress tests implemented

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
