### PR TITLE
BC-11133 - delay displaying of connection dialog 

### DIFF
--- a/src/modules/feature/board/board/Board.unit.ts
+++ b/src/modules/feature/board/board/Board.unit.ts
@@ -1189,21 +1189,21 @@ describe("Board", () => {
 			expect(wrapperVM.showLoadingDialog).toBe(false);
 		});
 
-		it("should return true when isConnected is false after 2000ms", async () => {
+		it("should return true when isConnected is false after 3000ms", async () => {
 			const { wrapperVM, boardStore } = setup();
 
 			boardStore.isConnected = false;
-			vi.advanceTimersByTime(2100);
+			await vi.advanceTimersByTimeAsync(3100);
 			await nextTick();
 
 			expect(wrapperVM.showLoadingDialog).toBe(true);
 		});
 
-		it("should return true when isLoading is true after 2000ms", async () => {
+		it("should return true when isLoading is true after 3000ms", async () => {
 			const { wrapperVM, boardStore } = setup();
 
 			boardStore.isLoading = true;
-			vi.advanceTimersByTime(2100);
+			await vi.advanceTimersByTimeAsync(3100);
 			await nextTick();
 
 			expect(wrapperVM.showLoadingDialog).toBe(true);

--- a/src/modules/feature/board/board/Board.unit.ts
+++ b/src/modules/feature/board/board/Board.unit.ts
@@ -1189,21 +1189,21 @@ describe("Board", () => {
 			expect(wrapperVM.showLoadingDialog).toBe(false);
 		});
 
-		it("should return true when isConnected is false after 500ms", async () => {
+		it("should return true when isConnected is false after 2000ms", async () => {
 			const { wrapperVM, boardStore } = setup();
 
 			boardStore.isConnected = false;
-			vi.advanceTimersByTime(600);
+			vi.advanceTimersByTime(2100);
 			await nextTick();
 
 			expect(wrapperVM.showLoadingDialog).toBe(true);
 		});
 
-		it("should return true when isLoading is true after 500ms", async () => {
+		it("should return true when isLoading is true after 2000ms", async () => {
 			const { wrapperVM, boardStore } = setup();
 
 			boardStore.isLoading = true;
-			vi.advanceTimersByTime(600);
+			vi.advanceTimersByTime(2100);
 			await nextTick();
 
 			expect(wrapperVM.showLoadingDialog).toBe(true);

--- a/src/modules/feature/board/board/Board.vue
+++ b/src/modules/feature/board/board/Board.vue
@@ -387,9 +387,14 @@ const isListBoard = computed(() => board.value?.layout === BoardLayout.LIST);
 provide(BOARD_IS_LIST_LAYOUT, isListBoard);
 
 const started2000msAgo = useTimeout(2000);
-const isLoadingOrNotConnected = computed(
-	() => started2000msAgo.value === true && (boardStore.isConnected === false || boardStore.isLoading)
-);
+const isLoadingOrNotConnected = computed(() => {
+	const result = started2000msAgo.value === true && (boardStore.isConnected === false || boardStore.isLoading);
+	console.log("isLoadingOrNotConnected", result, {
+		isConnected: boardStore.isConnected,
+		isLoading: boardStore.isLoading,
+	});
+	return result;
+});
 const showLoadingDialog = refDebounced(isLoadingOrNotConnected, 2000);
 
 const boardClasses = computed(() => {

--- a/src/modules/feature/board/board/Board.vue
+++ b/src/modules/feature/board/board/Board.vue
@@ -387,14 +387,9 @@ const isListBoard = computed(() => board.value?.layout === BoardLayout.LIST);
 provide(BOARD_IS_LIST_LAYOUT, isListBoard);
 
 const started2000msAgo = useTimeout(2000);
-const isLoadingOrNotConnected = computed(() => {
-	const result = started2000msAgo.value === true && (boardStore.isConnected === false || boardStore.isLoading);
-	console.log("isLoadingOrNotConnected", result, {
-		isConnected: boardStore.isConnected,
-		isLoading: boardStore.isLoading,
-	});
-	return result;
-});
+const isLoadingOrNotConnected = computed(
+	() => started2000msAgo.value === true && (boardStore.isConnected === false || boardStore.isLoading)
+);
 const showLoadingDialog = refDebounced(isLoadingOrNotConnected, 2000);
 
 const boardClasses = computed(() => {

--- a/src/modules/feature/board/board/Board.vue
+++ b/src/modules/feature/board/board/Board.vue
@@ -386,9 +386,9 @@ const isListBoard = computed(() => board.value?.layout === BoardLayout.LIST);
 
 provide(BOARD_IS_LIST_LAYOUT, isListBoard);
 
-const started500msAgo = useTimeout(500);
+const started2000msAgo = useTimeout(2000);
 const isConnectedOrLoading = computed(
-	() => started500msAgo.value && (boardStore.isConnected === false || boardStore.isLoading)
+	() => started2000msAgo.value && (boardStore.isConnected === false || boardStore.isLoading)
 );
 const showLoadingDialog = refDebounced(isConnectedOrLoading, 1000);
 

--- a/src/modules/feature/board/board/Board.vue
+++ b/src/modules/feature/board/board/Board.vue
@@ -390,7 +390,7 @@ const started2000msAgo = useTimeout(2000);
 const isLoadingOrNotConnected = computed(
 	() => started2000msAgo.value === true && (boardStore.isConnected === false || boardStore.isLoading)
 );
-const showLoadingDialog = refDebounced(isLoadingOrNotConnected, 2000);
+const showLoadingDialog = refDebounced(isLoadingOrNotConnected, 1000);
 
 const boardClasses = computed(() => {
 	const classes = ["d-flex", "flex-shrink-1", "board"];

--- a/src/modules/feature/board/board/Board.vue
+++ b/src/modules/feature/board/board/Board.vue
@@ -172,7 +172,7 @@ import { DefaultWireframe } from "@ui-layout";
 import { LightBox } from "@ui-light-box";
 import { SelectBoardLayoutDialog } from "@ui-room-details";
 import { BOARD_IS_LIST_LAYOUT, extractDataAttribute, useElementFocus } from "@util-board";
-import { useTimeout } from "@vueuse/core";
+import { refDebounced, useTimeout } from "@vueuse/core";
 import { SortableEvent } from "sortablejs";
 import { Sortable } from "sortablejs-vue3";
 import { computed, ComputedRef, onMounted, onUnmounted, provide, ref, watch } from "vue";
@@ -221,8 +221,6 @@ const moveCardOptions = ref<{ isDialogOpen: boolean; cardId: string }>({
 	isDialogOpen: false,
 	cardId: "",
 });
-
-const started500msAgo = useTimeout(500);
 
 const onCreateCard = async (columnId: string) => {
 	if (allowedOperations.value.createCard) boardStore.createCardRequest({ columnId });
@@ -388,15 +386,11 @@ const isListBoard = computed(() => board.value?.layout === BoardLayout.LIST);
 
 provide(BOARD_IS_LIST_LAYOUT, isListBoard);
 
-const showLoadingDialog = computed(() => {
-	if (started500msAgo.value === true && boardStore.isConnected === false) {
-		return true;
-	}
-	if (started500msAgo.value === true && boardStore.isLoading) {
-		return true;
-	}
-	return false;
-});
+const started500msAgo = useTimeout(500);
+const isConnectedOrLoading = computed(
+	() => started500msAgo.value && (boardStore.isConnected === false || boardStore.isLoading)
+);
+const showLoadingDialog = refDebounced(isConnectedOrLoading, 1000);
 
 const boardClasses = computed(() => {
 	const classes = ["d-flex", "flex-shrink-1", "board"];

--- a/src/modules/feature/board/board/Board.vue
+++ b/src/modules/feature/board/board/Board.vue
@@ -387,10 +387,10 @@ const isListBoard = computed(() => board.value?.layout === BoardLayout.LIST);
 provide(BOARD_IS_LIST_LAYOUT, isListBoard);
 
 const started2000msAgo = useTimeout(2000);
-const isConnectedOrLoading = computed(
-	() => started2000msAgo.value && (boardStore.isConnected === false || boardStore.isLoading)
+const isLoadingOrNotConnected = computed(
+	() => started2000msAgo.value === true && (boardStore.isConnected === false || boardStore.isLoading)
 );
-const showLoadingDialog = refDebounced(isConnectedOrLoading, 1000);
+const showLoadingDialog = refDebounced(isLoadingOrNotConnected, 2000);
 
 const boardClasses = computed(() => {
 	const classes = ["d-flex", "flex-shrink-1", "board"];


### PR DESCRIPTION
# Short Description
Displaying the dialog for having no connection should be delayed - to not irritate anybody.

## Links to Ticket and related Pull-Requests
BC-11133
https://github.com/hpi-schul-cloud/nuxt-client/pull/4158
https://github.com/hpi-schul-cloud/schulcloud-server/pull/6248

## Changes

<!--
- What will the PR change?
- Why are the changes required?
- Links to documentation / tickets if exists, or provide more details here.
-->

## Data-security

<!--
Please note here about:
- any data model changes
- any changes about logging of user data
- any changes about permissions
- user input, authentication and other user data related things
If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
Keep in mind to changes to seed data, if changes are done by migration scripts.
Changes to the infrastructure have to discussed with the devops.
This information should be also in corresponding ticket, and collected in release deployment ticket.

This point should includes following information:
- What else is required for its deployment?
- Environment variables like FEATURE_XY=true
- Are there any migration scripts to be run?
-->

## New Repos, NPM packages or vendor scripts

<!--
- Keep in mind the stability, performance, activity and author.
- Describe why it is needed.
-->

## Screenshots of UI changes

<!--
- For UI changes, insert screenshots here.
- Has it been reviewed by a UX colleague?
-->

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)
- [x] Cypress: Every new feature has suitable Cypress tests implemented

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
