### PR TITLE
BC-11872-navigate to vue-client news detail page

### DIFF
--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -71,6 +71,7 @@ export default {
 	"common.labels.complete.lastName": "Vollständiger Nachname",
 	"common.labels.consent": "Einverständnis",
 	"common.labels.course": "Kurs",
+	"common.labels.team": "Team",
 	"common.labels.createAt": "Erstellt:",
 	"common.labels.createdAt": "Erstellungsdatum",
 	"common.labels.date": "Datum",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -69,6 +69,7 @@ export default {
 	"common.labels.complete.lastName": "Full surname",
 	"common.labels.consent": "Consent",
 	"common.labels.course": "Course",
+	"common.labels.team": "Team",
 	"common.labels.createAt": "Created:",
 	"common.labels.createdAt": "Created At",
 	"common.labels.date": "Date",

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -71,6 +71,7 @@ export default {
 	"common.labels.complete.lastName": "Apellido completo",
 	"common.labels.consent": "Consentimiento",
 	"common.labels.course": "Curso",
+	"common.labels.team": "Equipo",
 	"common.labels.createAt": "Creado:",
 	"common.labels.createdAt": "Creado en",
 	"common.labels.date": "Fecha",

--- a/src/locales/uk.ts
+++ b/src/locales/uk.ts
@@ -71,6 +71,7 @@ export default {
 	"common.labels.complete.lastName": "Повне прізвище",
 	"common.labels.consent": "Згода",
 	"common.labels.course": "Курс",
+	"common.labels.team": "Команда",
 	"common.labels.createAt": "Створено:",
 	"common.labels.createdAt": "Створено в",
 	"common.labels.date": "Дата",

--- a/src/modules/page/news/NewsDetails.page.vue
+++ b/src/modules/page/news/NewsDetails.page.vue
@@ -31,11 +31,6 @@
 							<VIcon :icon="mdiAccountGroupOutline" size="sm" class="mr-1" />
 							<a :href="`/teams/${newsInstance.targetId}`">{{ newsInstance.target.name }}</a>
 						</template>
-
-						<template v-if="newsInstance.targetModel === 'courses'">
-							<VIcon :icon="mdiAccountGroupOutline" size="sm" class="mr-1" />
-							<RouterLink :to="`/rooms/${newsInstance.targetId}`">{{ newsInstance.target.name }}</RouterLink>
-						</template>
 					</div>
 				</div>
 				<VDivider class="mb-4" />

--- a/src/modules/page/news/NewsDetails.page.vue
+++ b/src/modules/page/news/NewsDetails.page.vue
@@ -21,9 +21,21 @@
 						<VIcon :icon="mdiClockOutline" size="sm" class="mr-1" />
 						{{ displayedDateText }}
 					</div>
-					<div class="d-flex align-center text-subtitle" data-testid="news-creator">
+					<div class="d-flex align-center text-subtitle mr-3" data-testid="news-creator">
 						<VIcon :icon="mdiAccountCircleOutline" size="sm" class="mr-1" />
 						{{ creator }}
+					</div>
+
+					<div class="d-flex align-center text-subtitle" data-testid="news-creator">
+						<template v-if="newsInstance.targetModel === 'teams'">
+							<VIcon :icon="mdiAccountGroupOutline" size="sm" class="mr-1" />
+							<a :href="`/teams/${newsInstance.targetId}`">{{ newsInstance.target.name }}</a>
+						</template>
+
+						<template v-if="newsInstance.targetModel === 'courses'">
+							<VIcon :icon="mdiAccountGroupOutline" size="sm" class="mr-1" />
+							<RouterLink :to="`/rooms/${newsInstance.targetId}`">{{ newsInstance.target.name }}</RouterLink>
+						</template>
 					</div>
 				</div>
 				<VDivider class="mb-4" />
@@ -70,7 +82,7 @@ import { buildPageTitle } from "@/utils/pageTitle";
 import { useNews, useNewsActions } from "@data-access";
 import { notifySuccess, useAppStoreRefs } from "@data-app";
 import { RenderHTML } from "@feature-render-html";
-import { mdiAccountCircleOutline, mdiClockOutline } from "@icons/material";
+import { mdiAccountCircleOutline, mdiAccountGroupOutline, mdiClockOutline } from "@icons/material";
 import { SvsLoading } from "@ui-containers";
 import { EmptyState } from "@ui-empty-state";
 import { DefaultWireframe } from "@ui-layout";
@@ -78,7 +90,6 @@ import { useTitle } from "@vueuse/core";
 import { computed, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
-
 const { t } = useI18n();
 const router = useRouter();
 const route = useRoute();

--- a/src/modules/page/news/NewsEdit.page.vue
+++ b/src/modules/page/news/NewsEdit.page.vue
@@ -18,6 +18,13 @@
 		]"
 		max-width="short"
 	>
+		<div class="d-flex align-center text-subtitle mb-4" data-testid="news-creator">
+			<template v-if="newsInstance.targetModel === 'teams'">
+				<span class="mr-2">{{ t("common.labels.team") }}:</span>
+				<VIcon :icon="mdiAccountGroupOutline" size="sm" class="mr-1" />
+				<a :href="`/teams/${newsInstance.targetId}`">{{ newsInstance.target.name }}</a>
+			</template>
+		</div>
 		<NewsForm
 			:title="newsInstance.title"
 			:content="newsInstance.content"
@@ -37,6 +44,7 @@ import { type UpdateNewsParams } from "@api-server";
 import { useNews, useNewsActions } from "@data-access";
 import { notifySuccess } from "@data-app";
 import { NewsForm } from "@feature-news";
+import { mdiAccountGroupOutline } from "@icons/material";
 import { DefaultWireframe } from "@ui-layout";
 import { useTitle } from "@vueuse/core";
 import { computed, watch } from "vue";


### PR DESCRIPTION
# Short Description

Link from legacy team news list now points to nuxt-client news details page
Also added team relation with link to team in newsdetail and newsedit page

## Links to Ticket and related Pull-Requests

BC-11872

## Changes

## Data-security

## Deployment

## New Repos, NPM packages or vendor scripts

## Screenshots of UI changes
<img width="883" height="542" alt="image" src="https://github.com/user-attachments/assets/b1ffbe96-1708-4234-9b20-eac71d796052" />


## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [ ] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)
- [ ] Cypress: Every new feature has suitable Cypress tests implemented

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
