### PR TITLE
BC-11870 - do not display teams migration banner for dbc

### DIFF
--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -1008,6 +1008,9 @@ export default {
 	"mixins.typeMeta.types.image": "Bild",
 	"mixins.typeMeta.types.video": "Video",
 	"mixins.typeMeta.types.webpage": "Webseite",
+	"loggedin.text.backupFeatures":
+		"Sichern Sie Ihre Inhalte der Cloud und nutzen Sie auch die neue Funktion zum Export von Kursen. {helpLink}",
+	"loggedin.text.backupFeatures.helpLink": "Weitere Informationen und Hilfestellungen sind hier zu finden.",
 	"loggedin.text.schoolInTransferPhaseContactAdmin":
 		"Die Schule befindet sich in der Transferphase zum neuen Schuljahr. Es können keine Klassen und Nutzer:innen angelegt werden. Bitte kontaktiere deinen Schul-Admin!",
 	"loggedin.text.schoolInTransferPhaseStartNew":

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -982,6 +982,9 @@ export default {
 	"mixins.typeMeta.types.image": "Image",
 	"mixins.typeMeta.types.video": "Video",
 	"mixins.typeMeta.types.webpage": "Website",
+	"loggedin.text.backupFeatures":
+		"Back up your cloud content and also use the new function for exporting courses. {helpLink}",
+	"loggedin.text.backupFeatures.helpLink": "More information and instructions can be found here.",
 	"loggedin.text.schoolInTransferPhaseContactAdmin":
 		"The school is in the transfer phase to the new school year. No classes and users can be created. Please contact the school administrator!",
 	"loggedin.text.schoolInTransferPhaseStartNew":

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -1002,6 +1002,9 @@ export default {
 	"mixins.typeMeta.types.image": "Imagen",
 	"mixins.typeMeta.types.video": "Vídeo",
 	"mixins.typeMeta.types.webpage": "Página web",
+	"loggedin.text.backupFeatures":
+		"Haga una copia de seguridad de sus contenidos de la nube y utilice también la nueva función para exportar cursos. {helpLink}",
+	"loggedin.text.backupFeatures.helpLink": "Más información y ayuda disponible aquí",
 	"loggedin.text.schoolInTransferPhaseContactAdmin":
 		"La escuela está en fase de transferencia al nuevo año escolar. No se pueden crear clases ni usuarios. ¡Ponte en contacto con el administrador de la escuela!",
 	"loggedin.text.schoolInTransferPhaseStartNew":

--- a/src/locales/uk.ts
+++ b/src/locales/uk.ts
@@ -998,6 +998,9 @@ export default {
 	"mixins.typeMeta.types.image": "Зображення",
 	"mixins.typeMeta.types.video": "Відео",
 	"mixins.typeMeta.types.webpage": "Веб-сайт",
+	"loggedin.text.backupFeatures":
+		"Зробіть резервну копію вашого контенту в хмарі та використовуйте також нову функцію для експорту курсів. {helpLink}",
+	"loggedin.text.backupFeatures.helpLink": "Додаткову інформацію та допомогу можна знайти тут.",
 	"loggedin.text.schoolInTransferPhaseContactAdmin":
 		"Школа перебуває у фазі переходу до нового навчального року. Не можна створювати класи та користувачів.",
 	"loggedin.text.schoolInTransferPhaseStartNew":

--- a/src/pages/Dashboard.page.unit.ts
+++ b/src/pages/Dashboard.page.unit.ts
@@ -156,7 +156,7 @@ describe("DashboardPage", () => {
 			expect(warningAlert.text()).toContain("loggedin.text.teamsToRooms.helpLink");
 		});
 
-		it("is not always visible when dbc", async () => {
+		it("is not visible when dbc", async () => {
 			createTestEnvStore({ SC_THEME: SchulcloudTheme.DEFAULT });
 			const { wrapper } = setup();
 			await flushPromises();

--- a/src/pages/Dashboard.page.unit.ts
+++ b/src/pages/Dashboard.page.unit.ts
@@ -2,6 +2,7 @@ import DashboardPage from "./Dashboard.page.vue";
 import { initializeAxios } from "@/utils/api";
 import {
 	createTestAppStore,
+	createTestEnvStore,
 	mockApi,
 	mockApiResponse,
 	mockAxiosInstance,
@@ -18,6 +19,7 @@ import {
 	ReleaseItemResponse,
 	RoleName,
 	RuntimeConfigApiInterface,
+	SchulcloudTheme,
 } from "@api-server";
 import { DashboardTasks } from "@feature-dashboard";
 import { createTestingPinia } from "@pinia/testing";
@@ -141,7 +143,8 @@ describe("DashboardPage", () => {
 	});
 
 	describe("teams-to-rooms warning", () => {
-		it("is always visible and renders the expected content", async () => {
+		it("is visible and renders the expected content when not dbc", async () => {
+			createTestEnvStore({ SC_THEME: SchulcloudTheme.N21 });
 			const { wrapper } = setup();
 			await flushPromises();
 
@@ -151,6 +154,15 @@ describe("DashboardPage", () => {
 			expect(warningAlert.text()).toContain("loggedin.text.teamsToRooms.possibilities");
 			expect(warningAlert.text()).toContain("loggedin.text.teamsToRooms.migration");
 			expect(warningAlert.text()).toContain("loggedin.text.teamsToRooms.helpLink");
+		});
+
+		it("is not always visible when dbc", async () => {
+			createTestEnvStore({ SC_THEME: SchulcloudTheme.DEFAULT });
+			const { wrapper } = setup();
+			await flushPromises();
+
+			const warningAlert = wrapper.findComponent("[data-testid='teams-to-rooms-migration-alert']");
+			expect(warningAlert.exists()).toBe(false);
 		});
 	});
 

--- a/src/pages/Dashboard.page.vue
+++ b/src/pages/Dashboard.page.vue
@@ -6,7 +6,7 @@
 		<template #default>
 			<Announcement class="mt-6" />
 			<!-- Teams to Rooms Migration Alert, should completely be deleted after migration -->
-			<WarningAlert class="mt-6" data-testid="teams-to-rooms-migration-alert">
+			<WarningAlert v-if="!isDbc" class="mt-6" data-testid="teams-to-rooms-migration-alert">
 				<span class="font-weight-bold">{{ t("loggedin.text.teamsToRooms") }}</span>
 
 				<ul class="mt-1 pl-5">
@@ -23,6 +23,15 @@
 					</li>
 				</ul>
 			</WarningAlert>
+			<InfoAlert v-if="isDbc && (isTeacher || isAdmin)" class="mt-6">
+				<i18n-t keypath="loggedin.text.backupFeatures" scope="global">
+					<template #helpLink>
+						<a href="https://dbildungscloud.de/help/confluence/485132545" target="_blank" rel="noopener noreferrer">
+							{{ t("loggedin.text.backupFeatures.helpLink") }}
+						</a>
+					</template>
+				</i18n-t>
+			</InfoAlert>
 
 			<WarningAlert v-if="inMaintenanceOrMigrationText" class="mt-4" data-testid="maintenance-migration-alert">
 				<RenderHTML :html="inMaintenanceOrMigrationText" />
@@ -83,14 +92,15 @@ import SvgNewsEmpty from "@/assets/img/SvgNewsEmpty.vue";
 import Announcement from "@/components/announcement/Announcement.vue";
 import { fromNowUtc } from "@/utils/date-time.utils";
 import { buildPageTitle } from "@/utils/pageTitle";
-import { NewsTargetModel, Permission } from "@api-server";
+import { NewsTargetModel, Permission, SchulcloudTheme } from "@api-server";
 import { useNewsList } from "@data-access";
 import { useAppStore, useAppStoreRefs } from "@data-app";
 import { useSchoolStoreRefs } from "@data-app";
+import { useEnvConfig } from "@data-env";
 import { DashboardReleaseDialog, DashboardTasks } from "@feature-dashboard";
 import { RenderHTML } from "@feature-render-html";
 import { mdiNewspaperVariantOutline } from "@icons/material";
-import { WarningAlert } from "@ui-alert";
+import { InfoAlert, WarningAlert } from "@ui-alert";
 import { SvsLoading } from "@ui-containers";
 import { EmptyState } from "@ui-empty-state";
 import { DefaultWireframe } from "@ui-layout";
@@ -128,6 +138,8 @@ const helpAriaLabel = computed(
 	() => `${t("pages.rooms.infoAlert.welcome.furtherInformation.help")}, ${t("common.ariaLabel.newTab")}`
 );
 const helpLink = computed(() => `${window.location.origin}/help/confluence/426313035`);
+
+const isDbc = computed(() => useEnvConfig().value.SC_THEME === SchulcloudTheme.DEFAULT);
 </script>
 
 <style scoped>


### PR DESCRIPTION
# Short Description

Reactivate dbc banner in dashboard and suppress teams migration banner in all occurences

## Links to Ticket and related Pull-Requests

BC-11870

## Changes

## Data-security

## Deployment

## New Repos, NPM packages or vendor scripts

## Screenshots of UI changes

## Checklist before merging

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [ ] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)
- [ ] Cypress: Every new feature has suitable Cypress tests implemented

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
