### PR TITLE
BC-11802 - External tool not visible after adding to board

### DIFF
--- a/src/modules/feature/board/shared/InlineEditInteractionHandler.unit.ts
+++ b/src/modules/feature/board/shared/InlineEditInteractionHandler.unit.ts
@@ -126,6 +126,29 @@ describe("InlineEditInteractionHandler", () => {
 				const emitted = wrapper.emitted();
 				expect(emitted["end-edit-mode"]).toBeUndefined();
 			});
+
+			it("should not emit 'end-edit-mode' if the target is inside a Vuetify dialog", () => {
+				const event = document.createEvent("MouseEvent");
+				const dialogElement = document.createElement("div");
+				dialogElement.classList.add("v-dialog");
+				const inputElement = document.createElement("input");
+				dialogElement.appendChild(inputElement);
+
+				Object.defineProperty(event, "target", {
+					value: inputElement,
+					writable: false,
+				});
+
+				const { wrapper } = setup({ isEditMode: true });
+
+				const outsideHandler = wrapper.findComponent({
+					name: "OnClickOutside",
+				});
+				outsideHandler.vm.$emit("trigger", event);
+
+				const emitted = wrapper.emitted();
+				expect(emitted["end-edit-mode"]).toBeUndefined();
+			});
 		});
 
 		describe("when double clicked", () => {

--- a/src/modules/feature/board/shared/InlineEditInteractionHandler.vue
+++ b/src/modules/feature/board/shared/InlineEditInteractionHandler.vue
@@ -50,6 +50,8 @@ const isKeepInlineEditModeButton = (target: HTMLElement | SVGElement): boolean =
 	return button.className?.includes("keep-inline-edit-mode");
 };
 
+const isDialog = (target: HTMLElement | SVGElement): boolean | void => !!target.closest(".v-dialog");
+
 const hasTextSelection = (): boolean => {
 	const selection = window.getSelection();
 	return selection !== null && selection.toString().length > 0;
@@ -59,7 +61,7 @@ const isAllowedTarget = (event: Event): boolean => {
 	const target = event.target as HTMLElement | SVGElement;
 	if (!(target instanceof HTMLElement) && !(target instanceof SVGElement)) return true;
 
-	const disallowedConditions = [isListItem, isDatePicker, isFileElementLink, isKeepInlineEditModeButton];
+	const disallowedConditions = [isListItem, isDatePicker, isFileElementLink, isKeepInlineEditModeButton, isDialog];
 
 	return target && disallowedConditions.every((fn) => !fn(target));
 };


### PR DESCRIPTION
# Short Description
When adding an external tool to a card, then the board directly switches to view mode when clicking inside the dialog to configure the new tool.
<!-- Write a short explanation of what this Pull Request does -->

<!--
  This Pull-Request template helps the reviewers as well as servers as a checklist for you. Please feel out all possible sections.

  Quality guidelines:
    - Code should be self-explanatory; Document code that is not self-explanatory
    - Code respects SOLID principles, DRY, YAGNI, KISS
    - Think about potential bugs this Pull Request might introduce
    - Keep security in mind
    - Write tests (Unit and Integration), including for error cases. Don't decrease coverage
    - Business logic should be implemented in the API; never trust the client
    - UI changes should be discussed & agreed with the UX-Team before staring
    - Boyscout rule: leave the code in a better state than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Ticket and related Pull-Requests
BC-11802
https://github.com/hpi-schul-cloud/e2e-system-tests/pull/564
<!--
Base links to copy
- https://ticketsystem.dbildungscloud.de/browse/BC-????
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://github.com/hpi-schul-cloud/end-to-end-tests/pull/????
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
-->
<!-- related-prs-and-tickets-start -->
<!-- related-prs-and-tickets-end -->

## Changes
- dont leave edit mode when clicking inside dialog
<!--
- What will the PR change?
- Why are the changes required?
- Links to documentation / tickets if exists, or provide more details here.
-->

## Screenshots of UI changes
<img width="709" height="578" alt="grafik" src="https://github.com/user-attachments/assets/eed7c187-98df-467f-9e79-5abb3ac970af" />

<!--
- For UI changes, insert screenshots here.
- Has it been reviewed by a UX colleague?
-->

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)
- [x] Cypress: Every new feature has suitable Cypress tests implemented

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
