### PR TITLE
BC-11805 - Avoid showing disconnected modal in board when using websockets

### DIFF
--- a/src/modules/feature/board/board/Board.vue
+++ b/src/modules/feature/board/board/Board.vue
@@ -123,7 +123,7 @@
 		<VDialog :model-value="showLoadingDialog" class="w-33" :persistent="true">
 			<VCard class="pa-4">
 				<VCard-text class="text-center">
-					<div v-if="boardStore.isConnected === false && board" class="text-center" data-testid="dialog-text">
+					<div class="text-center" data-testid="dialog-text">
 						{{ t("error.ws.connectionLost") }}
 					</div>
 					<VProgressCircular color="primary" indeterminate :size="36" class="my-4" />
@@ -173,7 +173,7 @@ import { DefaultWireframe } from "@ui-layout";
 import { LightBox } from "@ui-light-box";
 import { SelectBoardLayoutDialog } from "@ui-room-details";
 import { BOARD_IS_LIST_LAYOUT, extractDataAttribute, useElementFocus } from "@util-board";
-import { refDebounced, useTimeout } from "@vueuse/core";
+import { useTimeout } from "@vueuse/core";
 import { SortableEvent } from "sortablejs";
 import { Sortable } from "sortablejs-vue3";
 import { computed, ComputedRef, onUnmounted, provide, ref, watch } from "vue";
@@ -196,6 +196,7 @@ const { allowedOperations } = useBoardAllowedOperations();
 const { breadcrumbs, contextType, roomId, createPageInformation, resetPageInformation } =
 	useSharedBoardPageInformation();
 const isDragging = ref(false);
+const showLoadingDialog = ref(false);
 const isEditSettingsDialogOpen = ref(false);
 const router = useRouter();
 
@@ -383,11 +384,22 @@ const isListBoard = computed(() => board.value?.layout === BoardLayout.LIST);
 
 provide(BOARD_IS_LIST_LAYOUT, isListBoard);
 
-const started2000msAgo = useTimeout(2000);
+const TwoSecondsPassedSinceInitialRender = useTimeout(2000);
 const isLoadingOrNotConnected = computed(
-	() => started2000msAgo.value === true && (boardStore.isConnected === false || boardStore.isLoading)
+	() => TwoSecondsPassedSinceInitialRender.value === true && (boardStore.isConnected === false || boardStore.isLoading)
 );
-const showLoadingDialog = refDebounced(isLoadingOrNotConnected, 1000);
+
+watch(isLoadingOrNotConnected, (newValue) => {
+	if (!newValue) {
+		showLoadingDialog.value = false;
+	} else {
+		setTimeout(() => {
+			if (isLoadingOrNotConnected.value) {
+				showLoadingDialog.value = true;
+			}
+		}, 1000);
+	}
+});
 
 const boardClasses = computed(() => {
 	const classes = ["d-flex", "flex-shrink-1", "board"];

--- a/src/modules/feature/board/board/Board.vue
+++ b/src/modules/feature/board/board/Board.vue
@@ -384,11 +384,13 @@ const isListBoard = computed(() => board.value?.layout === BoardLayout.LIST);
 
 provide(BOARD_IS_LIST_LAYOUT, isListBoard);
 
-const TwoSecondsPassedSinceInitialRender = useTimeout(2000);
+const twoSecondsPassedSinceInitialRender = useTimeout(2000);
 const isLoadingOrNotConnected = computed(
-	() => TwoSecondsPassedSinceInitialRender.value === true && (boardStore.isConnected === false || boardStore.isLoading)
+	() => twoSecondsPassedSinceInitialRender.value === true && (boardStore.isConnected === false || boardStore.isLoading)
 );
 
+// Show loading dialog if the board is loading or not connected for more than 1 second
+// Hide loading dialog immediately when connection is restored
 watch(isLoadingOrNotConnected, (newValue) => {
 	if (!newValue) {
 		showLoadingDialog.value = false;


### PR DESCRIPTION
# Short Description

Since the condition to show/hide the dialog was debounced it was always taking at least one second to appear/disappear. When users went back to an active tab and the socket connection got established immediately they would still see the dialog and spinner for one second.

Debouncing should only happen in one direction, to avoid showing the dialog for only-split seconds. Upon reconnect it now disappears immediately. When the connection is lost it waits for one second, checks again whether the connection still is not there and then shows the dialog.

<!-- Write a short explanation of what this Pull Request does -->

<!--
  This Pull-Request template helps the reviewers as well as servers as a checklist for you. Please feel out all possible sections.

  Quality guidelines:
    - Code should be self-explanatory; Document code that is not self-explanatory
    - Code respects SOLID principles, DRY, YAGNI, KISS
    - Think about potential bugs this Pull Request might introduce
    - Keep security in mind
    - Write tests (Unit and Integration), including for error cases. Don't decrease coverage
    - Business logic should be implemented in the API; never trust the client
    - UI changes should be discussed & agreed with the UX-Team before staring
    - Boyscout rule: leave the code in a better state than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Ticket and related Pull-Requests

BC-11805

<!--
Base links to copy
- https://ticketsystem.dbildungscloud.de/browse/BC-????
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://github.com/hpi-schul-cloud/end-to-end-tests/pull/????
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
-->
<!-- related-prs-and-tickets-start -->
<!-- related-prs-and-tickets-end -->

## Changes

<!--
- What will the PR change?
- Why are the changes required?
- Links to documentation / tickets if exists, or provide more details here.
-->

## Data-security

<!--
Please note here about:
- any data model changes
- any changes about logging of user data
- any changes about permissions
- user input, authentication and other user data related things
If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
Keep in mind to changes to seed data, if changes are done by migration scripts.
Changes to the infrastructure have to discussed with the devops.
This information should be also in corresponding ticket, and collected in release deployment ticket.

This point should includes following information:
- What else is required for its deployment?
- Environment variables like FEATURE_XY=true
- Are there any migration scripts to be run?
-->

## New Repos, NPM packages or vendor scripts

<!--
- Keep in mind the stability, performance, activity and author.
- Describe why it is needed.
-->

## Screenshots of UI changes

<!--
- For UI changes, insert screenshots here.
- Has it been reviewed by a UX colleague?
-->

## Checklist before merging

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [ ] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)
- [ ] Cypress: Every new feature has suitable Cypress tests implemented

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
