### PR TITLE
BC-11161 - disconnect websocket-connection on folder-page

### DIFF
--- a/src/modules/data/board/socket/socket.ts
+++ b/src/modules/data/board/socket/socket.ts
@@ -86,7 +86,7 @@ export const useSocketConnection = (dispatch: (action: Action) => void) => {
 	};
 
 	useEventListener(document, "visibilitychange", () => {
-		if (document.visibilityState === "visible") {
+		if (document.visibilityState === "visible" && instance !== null) {
 			// tab got visible again, ensure socket is connected and up to date
 			getConnectedSocket();
 		}

--- a/src/modules/data/board/socket/socket.unit.ts
+++ b/src/modules/data/board/socket/socket.unit.ts
@@ -17,6 +17,10 @@ const { mockIsJwtExpired } = vi.hoisted(() => {
 	return { mockIsJwtExpired: vueRef(false) as Ref<boolean> };
 });
 
+const { visibilityChangeListeners } = vi.hoisted(() => ({
+	visibilityChangeListeners: [] as Array<() => void>,
+}));
+
 vi.mock("axios");
 
 vi.mock("vue-i18n");
@@ -24,6 +28,19 @@ vi.mock("vue-i18n");
 
 vi.mock("socket.io-client");
 const mockSocketIOClient = vi.mocked(socketModule);
+
+vi.mock("@vueuse/core", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@vueuse/core")>();
+	return {
+		...actual,
+		useEventListener: vi.fn((_, event: string, listener: EventListenerOrEventListenerObject) => {
+			if (event !== "visibilitychange") return vi.fn();
+			const callback = typeof listener === "function" ? listener : (evt: Event) => listener.handleEvent(evt);
+			visibilityChangeListeners.push(() => callback(new Event("visibilitychange")));
+			return vi.fn();
+		}),
+	};
+});
 
 vi.mock("../boardActions/boardSocketApi.composable", () => ({
 	useBoardSocketApi: vi.fn(() => ({ duplicateColumnRequest: vi.fn() })),
@@ -119,6 +136,7 @@ describe("socket.ts", () => {
 		vi.clearAllMocks();
 		resetSocketStateForTesting();
 		mockIsJwtExpired.value = false;
+		visibilityChangeListeners.length = 0;
 	});
 
 	const getEventCallbacks = (eventName: string): Fn[] => {
@@ -424,6 +442,41 @@ describe("socket.ts", () => {
 			getConnectedSocket();
 
 			expect(connected.value).toBe(false);
+		});
+	});
+
+	describe("visibilitychange event", () => {
+		describe("when tab becomes visible", () => {
+			const mockVisibilityChange = (visibilityState: string) => {
+				Object.defineProperty(document, "visibilityState", {
+					configurable: true,
+					value: visibilityState,
+				});
+
+				visibilityChangeListeners.forEach((listener) => listener());
+			};
+
+			describe("when socket instance exists", () => {
+				it("should ensure socket is connected", () => {
+					setup();
+					mockSocket.connected = false;
+
+					mockVisibilityChange("visible");
+
+					expect(mockSocket.connect).toHaveBeenCalled();
+				});
+			});
+
+			describe("when socket instance does not exist", () => {
+				it("should not ensure socket is connected", () => {
+					useSocketConnection(dispatchMock);
+
+					mockVisibilityChange("visible");
+
+					expect(mockSocketIOClient.io).not.toHaveBeenCalled();
+					expect(mockSocket.connect).not.toHaveBeenCalled();
+				});
+			});
 		});
 	});
 });


### PR DESCRIPTION
# Short Description
When user leaves the board by clicking on a folder-element (resulting in opening a separate tab), this tab should not keep a websocket-connection and should not create a new connection once the user makes the page visible again.

- disconnect when user opens folder page (was implemented earlier)
- prevent socket-connection from being reestablished, if no instance exists

## Links to Ticket and related Pull-Requests
BC-11161

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)
- [x] Cypress: Every new feature has suitable Cypress tests implemented

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
