### PR TITLE
BC-12074 Fix FileContentElement state display and user warning

### DIFF
--- a/src/modules/feature/board-file-element/FileContentElement.unit.ts
+++ b/src/modules/feature/board-file-element/FileContentElement.unit.ts
@@ -1609,4 +1609,83 @@ describe("FileContentElement", () => {
 			});
 		});
 	});
+
+	describe("beforeunload warning", () => {
+		const setup = () => {
+			const element = fileElementResponseFactory.build();
+
+			const fileStorageApiMock = mockComposable(FileStorageApi.useFileStorageApi, {
+				upload: vi.fn().mockReturnValue(new Promise(() => true)),
+				getFileRecordsByParentId: vi.fn().mockReturnValueOnce([]),
+			});
+			vi.spyOn(FileStorageApi, "useFileStorageApi").mockReturnValueOnce(fileStorageApiMock);
+
+			vi.mocked(useBoardAllowedOperations).mockReturnValue({
+				allowedOperations: computed(() => ({ createFileElement: true }) as unknown),
+			} as ReturnType<typeof useBoardAllowedOperations>);
+
+			const useContentElementStateMock = vi.mocked(useContentElementState);
+			const fileContentElement = fileElementResponseFactory.build();
+			useContentElementStateMock.mockReturnValueOnce({
+				modelValue: ref(fileContentElement),
+				computedElement: computed(() => fileContentElement),
+			});
+
+			const { wrapper } = getWrapper({
+				element,
+				isEditMode: true,
+				columnIndex: 0,
+				rowIndex: 1,
+				elementIndex: 2,
+			});
+
+			const startLocalUpload = async () => {
+				wrapper.findComponent(FileUpload).vm.$emit("upload:file", { fileName: "sample.txt" });
+				await nextTick();
+			};
+
+			const dispatchBeforeUnload = () => {
+				const beforeUnloadEvent = new Event("beforeunload");
+				const preventDefaultSpy = vi.fn();
+				beforeUnloadEvent.preventDefault = preventDefaultSpy;
+				window.dispatchEvent(beforeUnloadEvent);
+
+				return preventDefaultSpy;
+			};
+
+			return { wrapper, startLocalUpload, dispatchBeforeUnload };
+		};
+
+		it("should warn before leaving the page while a local upload is in progress", async () => {
+			const { startLocalUpload, dispatchBeforeUnload, wrapper } = setup();
+			await flushPromises();
+			await startLocalUpload();
+
+			const preventDefaultSpy = dispatchBeforeUnload();
+
+			expect(preventDefaultSpy).toHaveBeenCalled();
+			wrapper.unmount();
+		});
+
+		it("should not warn before leaving the page when no local upload is in progress", async () => {
+			const { dispatchBeforeUnload, wrapper } = setup();
+			await flushPromises();
+
+			const preventDefaultSpy = dispatchBeforeUnload();
+
+			expect(preventDefaultSpy).not.toHaveBeenCalled();
+			wrapper.unmount();
+		});
+
+		it("should remove the beforeunload listener on unmount", async () => {
+			const { wrapper, startLocalUpload, dispatchBeforeUnload } = setup();
+			await flushPromises();
+			await startLocalUpload();
+
+			wrapper.unmount();
+			const preventDefaultSpy = dispatchBeforeUnload();
+
+			expect(preventDefaultSpy).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/src/modules/feature/board-file-element/FileContentElement.unit.ts
+++ b/src/modules/feature/board-file-element/FileContentElement.unit.ts
@@ -1614,8 +1614,13 @@ describe("FileContentElement", () => {
 		const setup = () => {
 			const element = fileElementResponseFactory.build();
 
+			let resolveUpload!: () => void;
+			const uploadPromise = new Promise<void>((resolve) => {
+				resolveUpload = resolve;
+			});
+
 			const fileStorageApiMock = mockComposable(FileStorageApi.useFileStorageApi, {
-				upload: vi.fn().mockReturnValue(new Promise(() => true)),
+				upload: vi.fn().mockReturnValue(uploadPromise),
 				getFileRecordsByParentId: vi.fn().mockReturnValueOnce([]),
 			});
 			vi.spyOn(FileStorageApi, "useFileStorageApi").mockReturnValueOnce(fileStorageApiMock);
@@ -1644,6 +1649,11 @@ describe("FileContentElement", () => {
 				await nextTick();
 			};
 
+			const finishLocalUpload = async () => {
+				resolveUpload();
+				await flushPromises();
+			};
+
 			const dispatchBeforeUnload = () => {
 				const beforeUnloadEvent = new Event("beforeunload");
 				const preventDefaultSpy = vi.fn();
@@ -1653,36 +1663,36 @@ describe("FileContentElement", () => {
 				return preventDefaultSpy;
 			};
 
-			return { wrapper, startLocalUpload, dispatchBeforeUnload };
+			return { wrapper, startLocalUpload, finishLocalUpload, dispatchBeforeUnload };
 		};
 
 		it("should warn before leaving the page while a local upload is in progress", async () => {
-			const { startLocalUpload, dispatchBeforeUnload, wrapper } = setup();
+			const { startLocalUpload, dispatchBeforeUnload, finishLocalUpload } = setup();
 			await flushPromises();
 			await startLocalUpload();
 
 			const preventDefaultSpy = dispatchBeforeUnload();
 
 			expect(preventDefaultSpy).toHaveBeenCalled();
-			wrapper.unmount();
+
+			await finishLocalUpload();
 		});
 
 		it("should not warn before leaving the page when no local upload is in progress", async () => {
-			const { dispatchBeforeUnload, wrapper } = setup();
+			const { dispatchBeforeUnload } = setup();
 			await flushPromises();
 
 			const preventDefaultSpy = dispatchBeforeUnload();
 
 			expect(preventDefaultSpy).not.toHaveBeenCalled();
-			wrapper.unmount();
 		});
 
-		it("should remove the beforeunload listener on unmount", async () => {
-			const { wrapper, startLocalUpload, dispatchBeforeUnload } = setup();
+		it("should stop warning once the local upload has finished", async () => {
+			const { startLocalUpload, finishLocalUpload, dispatchBeforeUnload } = setup();
 			await flushPromises();
 			await startLocalUpload();
 
-			wrapper.unmount();
+			await finishLocalUpload();
 			const preventDefaultSpy = dispatchBeforeUnload();
 
 			expect(preventDefaultSpy).not.toHaveBeenCalled();

--- a/src/modules/feature/board-file-element/FileContentElement.vue
+++ b/src/modules/feature/board-file-element/FileContentElement.vue
@@ -80,7 +80,7 @@ import { BoardMenu, BoardMenuScope, EmptyElement } from "@ui-board";
 import { KebabMenuActionDelete, KebabMenuActionMoveDown, KebabMenuActionMoveUp } from "@ui-kebab-menu";
 import { LightBoxContentType, LightBoxOptions, useLightBox } from "@ui-light-box";
 import { useDebounceFn } from "@vueuse/core";
-import { computed, onMounted, ref, toRef, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, toRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 
@@ -120,8 +120,9 @@ const fileRecord = computed(() => getFileRecordsByParentId(element.value.id)[0])
 
 const { alerts, addAlert } = useFileAlerts(fileRecord);
 
-const isUploading = computed(() => fileRecord.value?.isUploading);
+const fileWasPicked = ref(false);
 const uploadProgress = ref(0);
+const isUploading = computed(() => fileRecord.value?.isUploading || fileWasPicked.value);
 
 const fileProperties = computed(() => {
 	if (fileRecord.value === undefined) {
@@ -162,9 +163,23 @@ watch(element.value, async () => {
 	isLoadingFileRecord.value = false;
 });
 
+const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+	if (fileWasPicked.value) {
+		// Opens confirmation dialog in firefox
+		event.preventDefault();
+		// Opens confirmation dialog in chrome
+		event.returnValue = "";
+	}
+};
+
 onMounted(async () => {
+	window.addEventListener("beforeunload", handleBeforeUnload);
 	await tryFetchFiles(element.value.id, FileRecordParentType.BOARDNODES);
 	isLoadingFileRecord.value = false;
+});
+
+onBeforeUnmount(() => {
+	window.removeEventListener("beforeunload", handleBeforeUnload);
 });
 
 const onKeydownArrow = (event: KeyboardEvent) => {
@@ -174,8 +189,9 @@ const onKeydownArrow = (event: KeyboardEvent) => {
 	}
 };
 
-const onUploadFile = async (file: File): Promise<void> => {
-	uploadProgress.value = 0;
+const onUploadFile = async (file: File) => {
+	fileWasPicked.value = true;
+  uploadProgress.value = 0;
 	try {
 		await upload(file, element.value.id, FileRecordParentType.BOARDNODES, (progress) => {
 			uploadProgress.value = progress;
@@ -184,7 +200,8 @@ const onUploadFile = async (file: File): Promise<void> => {
 	} catch {
 		emit("delete:element", element.value.id);
 	} finally {
-		uploadProgress.value = 0;
+		fileWasPicked.value = false;
+    uploadProgress.value = 0;
 	}
 };
 

--- a/src/modules/feature/board-file-element/FileContentElement.vue
+++ b/src/modules/feature/board-file-element/FileContentElement.vue
@@ -191,7 +191,7 @@ const onKeydownArrow = (event: KeyboardEvent) => {
 
 const onUploadFile = async (file: File) => {
 	fileWasPicked.value = true;
-  uploadProgress.value = 0;
+	uploadProgress.value = 0;
 	try {
 		await upload(file, element.value.id, FileRecordParentType.BOARDNODES, (progress) => {
 			uploadProgress.value = progress;
@@ -201,7 +201,7 @@ const onUploadFile = async (file: File) => {
 		emit("delete:element", element.value.id);
 	} finally {
 		fileWasPicked.value = false;
-    uploadProgress.value = 0;
+		uploadProgress.value = 0;
 	}
 };
 

--- a/src/modules/feature/board-file-element/FileContentElement.vue
+++ b/src/modules/feature/board-file-element/FileContentElement.vue
@@ -80,7 +80,7 @@ import { BoardMenu, BoardMenuScope, EmptyElement } from "@ui-board";
 import { KebabMenuActionDelete, KebabMenuActionMoveDown, KebabMenuActionMoveUp } from "@ui-kebab-menu";
 import { LightBoxContentType, LightBoxOptions, useLightBox } from "@ui-light-box";
 import { useDebounceFn } from "@vueuse/core";
-import { computed, onBeforeUnmount, onMounted, ref, toRef, watch } from "vue";
+import { computed, onMounted, ref, toRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 
@@ -168,18 +168,13 @@ const handleBeforeUnload = (event: BeforeUnloadEvent) => {
 		// Opens confirmation dialog in firefox
 		event.preventDefault();
 		// Opens confirmation dialog in chrome
-		event.returnValue = "";
+		event.returnValue = true;
 	}
 };
 
 onMounted(async () => {
-	window.addEventListener("beforeunload", handleBeforeUnload);
 	await tryFetchFiles(element.value.id, FileRecordParentType.BOARDNODES);
 	isLoadingFileRecord.value = false;
-});
-
-onBeforeUnmount(() => {
-	window.removeEventListener("beforeunload", handleBeforeUnload);
 });
 
 const onKeydownArrow = (event: KeyboardEvent) => {
@@ -192,6 +187,7 @@ const onKeydownArrow = (event: KeyboardEvent) => {
 const onUploadFile = async (file: File) => {
 	fileWasPicked.value = true;
 	uploadProgress.value = 0;
+	window.addEventListener("beforeunload", handleBeforeUnload);
 	try {
 		await upload(file, element.value.id, FileRecordParentType.BOARDNODES, (progress) => {
 			uploadProgress.value = progress;
@@ -202,6 +198,7 @@ const onUploadFile = async (file: File) => {
 	} finally {
 		fileWasPicked.value = false;
 		uploadProgress.value = 0;
+		window.removeEventListener("beforeunload", handleBeforeUnload);
 	}
 };
 

--- a/src/modules/feature/board-file-element/upload/FileUpload.unit.ts
+++ b/src/modules/feature/board-file-element/upload/FileUpload.unit.ts
@@ -4,7 +4,6 @@ import { mockComposable } from "@@/tests/test-utils";
 import { createTestingI18n, createTestingVuetify } from "@@/tests/test-utils/setup";
 import * as utilBoard from "@util-board";
 import { mount } from "@vue/test-utils";
-import { nextTick } from "vue";
 
 const setupUseSharedLastCreatedElementMock = () => {
 	const mockedUse = mockComposable(utilBoard.useSharedLastCreatedElement);
@@ -58,22 +57,9 @@ describe("FileUpload", () => {
 
 				expect(wrapper.html()).toContain(testSlot);
 			});
-
-			it("should not show notification on page unload", async () => {
-				setup();
-
-				const beforeUnloadEvent = new Event("beforeunload");
-				const preventDefaultSpy = vi.fn();
-				preventDefaultSpy.mockClear();
-
-				beforeUnloadEvent.preventDefault = preventDefaultSpy;
-				window.dispatchEvent(beforeUnloadEvent);
-
-				expect(preventDefaultSpy).not.toHaveBeenCalled();
-			});
 		});
 
-		describe("when file gets picked and is uploading", () => {
+		describe("when file gets picked", () => {
 			const setup = (fileName = "") => {
 				setupUseSharedLastCreatedElementMock();
 
@@ -111,52 +97,6 @@ describe("FileUpload", () => {
 				filePicker.vm.$emit("update:file", { fileName: "Test.jpg" });
 
 				expect(wrapper.emitted("upload:file")).toHaveLength(1);
-			});
-
-			it("should render v-progress-linear component", async () => {
-				const { wrapper } = setup();
-
-				const filePicker = wrapper.findComponent(FilePicker);
-				expect(filePicker.exists()).toBe(true);
-
-				filePicker.vm.$emit("update:file", { fileName: "Test.jpg" });
-
-				await nextTick();
-
-				const progressLinear = wrapper.findComponent({
-					name: "v-progress-linear",
-				});
-				expect(progressLinear.exists()).toBe(true);
-			});
-
-			it("should not render FilePicker component", async () => {
-				const { wrapper } = setup();
-
-				const filePicker = wrapper.findComponent(FilePicker);
-				expect(filePicker.exists()).toBe(true);
-
-				filePicker.vm.$emit("update:file", { fileName: "Test.jpg" });
-
-				await nextTick();
-
-				expect(filePicker.exists()).toBe(false);
-			});
-
-			it("should show notification on page unload", async () => {
-				const { wrapper } = setup();
-
-				const filePicker = wrapper.findComponent(FilePicker);
-				expect(filePicker.exists()).toBe(true);
-
-				filePicker.vm.$emit("update:file", { fileName: "Test.jpg" });
-
-				const beforeUnloadEvent = new Event("beforeunload");
-				const preventDefaultSpy = vi.fn();
-
-				beforeUnloadEvent.preventDefault = preventDefaultSpy;
-				window.dispatchEvent(beforeUnloadEvent);
-
-				expect(preventDefaultSpy).toHaveBeenCalled();
 			});
 		});
 
@@ -203,18 +143,6 @@ describe("FileUpload", () => {
 
 				const filePicker = wrapper.findComponent(FilePicker);
 				expect(filePicker.exists()).toBe(false);
-			});
-
-			it("should show notification on page unload", async () => {
-				setup();
-
-				const beforeUnloadEvent = new Event("beforeunload");
-				const preventDefaultSpy = vi.fn();
-
-				beforeUnloadEvent.preventDefault = preventDefaultSpy;
-				window.dispatchEvent(beforeUnloadEvent);
-
-				expect(preventDefaultSpy).toHaveBeenCalled();
 			});
 		});
 	});
@@ -268,18 +196,6 @@ describe("FileUpload", () => {
 				name: "v-progress-linear",
 			});
 			expect(progressLinear.exists()).toBe(false);
-		});
-
-		it("should show notification on page unload", async () => {
-			setup();
-
-			const beforeUnloadEvent = new Event("beforeunload");
-			const preventDefaultSpy = vi.fn();
-
-			beforeUnloadEvent.preventDefault = preventDefaultSpy;
-			window.dispatchEvent(beforeUnloadEvent);
-
-			expect(preventDefaultSpy).toHaveBeenCalled();
 		});
 	});
 });

--- a/src/modules/feature/board-file-element/upload/FileUpload.vue
+++ b/src/modules/feature/board-file-element/upload/FileUpload.vue
@@ -1,7 +1,7 @@
 <template>
 	<ContentElementBar v-if="isEditMode">
 		<template #element>
-			<div v-if="isUploading || fileWasPicked" class="d-flex align-center pt-1 mr-1">
+			<div v-if="isUploading" class="d-flex align-center pt-1 mr-1">
 				<VProgressLinear
 					data-testid="board-file-element-progress-bar"
 					:model-value="uploadProgress > 0 ? uploadProgress : undefined"
@@ -21,7 +21,7 @@
 import FilePicker from "./file-picker/FilePicker.vue";
 import { ContentElementBar } from "@ui-board";
 import { useSharedFileSelect, useSharedLastCreatedElement } from "@util-board";
-import { defineComponent, onBeforeUnmount, onMounted, ref } from "vue";
+import { defineComponent, onMounted, ref } from "vue";
 
 export default defineComponent({
 	name: "FileUpload",
@@ -35,22 +35,11 @@ export default defineComponent({
 	emits: ["upload:file"],
 	setup(props, { emit }) {
 		const isFilePickerOpen = ref(false);
-		const fileWasPicked = ref(false);
 
 		const { lastCreatedElementId, resetLastCreatedElementId } = useSharedLastCreatedElement();
 		const { isFileSelectOnMountEnabled } = useSharedFileSelect();
 
-		const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-			if (fileWasPicked.value || props.isUploading) {
-				// Opens confirmation dialog in firefox
-				event.preventDefault();
-				// Opens confirmation dialog in chrome
-				event.returnValue = "";
-			}
-		};
-
 		onMounted(() => {
-			window.addEventListener("beforeunload", handleBeforeUnload);
 			if (lastCreatedElementId.value !== props.elementId) {
 				return;
 			}
@@ -58,17 +47,11 @@ export default defineComponent({
 			resetLastCreatedElementId();
 		});
 
-		onBeforeUnmount(() => {
-			window.removeEventListener("beforeunload", handleBeforeUnload);
-		});
-
 		const onFileSelect = async (file: File) => {
-			fileWasPicked.value = true;
 			emit("upload:file", file);
 		};
 
 		return {
-			fileWasPicked,
 			isFilePickerOpen,
 			lastCreatedElementId,
 			onFileSelect,


### PR DESCRIPTION
# Short Description

After introducing EmptyElement for created, but not filled with content elements, the FileContentElement did not function as before anymore. See related ticket.

## Links to Ticket and related Pull-Requests
BC-12074

## Changes

## Data-security

## Deployment

## New Repos, NPM packages or vendor scripts

## Screenshots of UI changes

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [ ] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)
- [ ] Cypress: Every new feature has suitable Cypress tests implemented

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
